### PR TITLE
chore(engine): DROP DEAD MODELS["custom"] ENTRY (M7)

### DIFF
--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -19,7 +19,6 @@ SPEED_MIN, SPEED_MAX = 0.5, 2.0
 MODELS = {
     "clone": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit",
     "design": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit",
-    "custom": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit",
 }
 
 _model_cache = {}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -17,7 +17,7 @@ class TestModels:
     def test_model_keys(self):
         assert "clone" in MODELS
         assert "design" in MODELS
-        assert "custom" in MODELS
+        assert "custom" not in MODELS  # dropped in M7: dead code
 
     def test_model_ids_are_mlx(self):
         for key, model_id in MODELS.items():


### PR DESCRIPTION
## WHY

MODELS DICT IN `src/spanish_tts/engine.py` CARRIED A "custom" KEY
POINTING AT Qwen3-TTS-CustomVoice-8bit. NOTHING READ IT:

- NO `generate_custom` FUNCTION
- MCP SERVER ONLY WIRES "clone" AND "design" MODES
- NO CLI FLAG
- `_preload_models()` ONLY LOADS clone + design

DEAD WEIGHT. MISLEADING FOR ANYONE READING engine.py TO FIGURE OUT
WHAT MODES EXIST.

## WHAT

- DELETE `"custom"` ENTRY FROM `MODELS`
- UPDATE `test_model_keys` TO ASSERT `"custom" NOT IN MODELS` SO
  THE LINE DOES NOT QUIETLY RETURN LATER

## TEST

```
conda run -n qwen3-tts python -m pytest -q
# 75 passed in 2.14s
```

## FOLLOW-UP

IF CustomVoice SUPPORT WANTED LATER: ADD A REAL `generate_custom`
WITH THE Qwen3-TTS CustomVoice PROMPT FORMAT, NOT JUST A DICT ENTRY.

CLOSES CHECKBOX M7 IN #2.
