### PR TITLE
ci: SHA-PIN ACTIONS + DEPENDABOT AUTO-BUMP (CI-1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip


### PR DESCRIPTION
## WHY

`ci.yml` USED MUTABLE TAGS (`@v4`, `@v5`) FOR THIRD-PARTY ACTIONS.
IF `actions/checkout` OR `actions/setup-python` GOT COMPROMISED, THE
TAG COULD BE RE-POINTED AT MALICIOUS CODE AND RUN IN CI WITH REPO
SECRETS. NOT HYPOTHETICAL — SEE tj-actions/changed-files INCIDENT
MARCH 2025.

SHA PINS FREEZE EXECUTION AT A KNOWN GOOD COMMIT. TRAILING TAG
COMMENT PRESERVES HUMAN READABILITY.

## WHAT

COMMIT 1 — `.github/workflows/ci.yml`
- `actions/checkout@v4`     → `@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4`
- `actions/setup-python@v5` → `@a26af69be951a213d495a4c3e4e4022e16d87065  # v5`

COMMIT 2 — `.github/dependabot.yml` (new)
- Weekly `github-actions` ecosystem updates
- Dependabot rewrites SHAs + tag comments on each major/minor bump

## TEST

NO FUNCTIONAL CHANGE. CI WILL RUN ON MERGE USING THE PINNED
REVISIONS. SHA VALUES VERIFIED VIA `gh api repos/<action>/git/ref/tags/<v>`.

## FOLLOW-UP

DEPENDABOT WILL START OPENING UPDATE PRS ON WEEKLY CADENCE. REVIEW
+ MERGE THEM MANUALLY. CAN ADD A SECOND ECOSYSTEM (`pip`) LATER IF
WE WANT DEP UPDATES TOO.

CLOSES CHECKBOX CI-1 IN #2.
