### PR TITLE
docs(readme): NOTE LIBROSA POOCH CACHE CAVEAT (DOC-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ pip install -e ".[mlx,speed]"
 
 If `librosa` is not installed, the speed parameter degrades gracefully: generation succeeds with speed=1.0 behavior and a log warning is printed. This allows the package to work without the optional dependency.
 
+> Note for contributors: librosa pulls in `pooch`, which can silently download example assets on first use of `librosa.load` with built-in examples. Our `time_stretch` path does not trigger this, but if you extend the audio pipeline with `librosa.example(...)` or `librosa.load('librosa://...')`, expect a one-time network fetch on first call.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## WHY

`librosa` DRAGS IN `pooch` WHICH CAN SILENTLY DOWNLOAD EXAMPLE
ASSETS THE FIRST TIME A USER CALLS `librosa.load` WITH BUILT-IN
EXAMPLES OR `librosa.example(...)`. OUR SPEED PATH USES
`time_stretch` ON AN IN-MEMORY ARRAY SO IT NEVER TRIGGERS — BUT
ANYONE EXTENDING THE AUDIO PIPELINE LATER MIGHT HIT A SILENT
NETWORK CALL AND WONDER WHY.

ONE-LINE NOTE IN THE "Speed Control (Optional)" SECTION OF
README WARNS FUTURE CONTRIBUTORS.

## WHAT

- ONE BLOCKQUOTE NOTE ADDED TO `README.md`
- NO CODE CHANGE, NO TEST CHANGE

## FOLLOW-UP

CLOSES CHECKBOX DOC-1 IN #2.
