### PR TITLE
build(dev): ADD PRE-COMMIT HOOKS + RUFF CONFIG (DEV-1)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Revisions to ignore in `git blame` (and GitHub's blame UI).
+# Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# DEV-1: bulk ruff reformat of src/ and tests/
+3d3e174
+# DEV-1: bulk ruff reformat of scripts/
+41b6225

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,21 @@ updates:
       prefix: "ci"
     labels:
       - dependencies
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "build"
+    labels:
+      - dependencies
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "build"
+    labels:
+      - dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# DEV-1: keep PRs clean without agent effort.
+# Install once with `pip install pre-commit && pre-commit install`.
+# Hooks run on `git commit` against changed files only.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      # Lint (uses [tool.ruff.lint] in pyproject.toml).
+      - id: ruff-check
+        args: [--fix]
+      # Format (uses [tool.ruff.format] in pyproject.toml).
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict
+
+  # Fast, pytest-on-changed hook: runs on push only so local commits stay snappy.
+  # Skips when no Python changed. Adjust if your test suite changes.
+  - repo: local
+    hooks:
+      - id: pytest-changed
+        name: pytest (changed files smoke)
+        entry: bash -c 'python -m pytest -q -x --no-header'
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 # DEV-1: keep PRs clean without agent effort.
-# Install once with `pip install pre-commit && pre-commit install`.
-# Hooks run on `git commit` against changed files only.
+# Install once per clone:
+#   pip install -e ".[dev]"
+#   pre-commit install                     # commit-stage hooks
+#   pre-commit install --hook-type pre-push # push-stage pytest smoke
+
+default_language_version:
+  python: python3.11
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -23,13 +28,14 @@ repos:
         args: [--maxkb=500]
       - id: check-merge-conflict
 
-  # Fast, pytest-on-changed hook: runs on push only so local commits stay snappy.
-  # Skips when no Python changed. Adjust if your test suite changes.
+  # Fast pytest hook on push only. Runs the full suite with -x, skipping
+  # tests marked `slow` to match CI. Bypass on WIP pushes with
+  # `git push --no-verify` or `SKIP=pytest-fast git push`.
   - repo: local
     hooks:
-      - id: pytest-changed
-        name: pytest (changed files smoke)
-        entry: bash -c 'python -m pytest -q -x --no-header'
+      - id: pytest-fast
+        name: pytest (fast, on push)
+        entry: bash -c 'python -m pytest -q -x -m "not slow" --no-header'
         language: system
         types: [python]
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -171,18 +171,31 @@ MIT
 
 ## Contributing
 
-Pre-commit hooks keep the repo formatted and linted on every commit:
+Pre-commit hooks keep the repo formatted and linted on every commit.
 
 ```bash
 pip install -e ".[dev]"
-pre-commit install
+pre-commit install                       # commit-stage hooks
+pre-commit install --hook-type pre-push  # push-stage pytest smoke
 ```
 
-Now `git commit` runs `ruff check --fix` and `ruff format` on changed files, plus basic hygiene hooks (trailing whitespace, EOF, YAML/TOML syntax, merge-conflict markers, 500KB file-size cap). A pytest smoke hook runs on `git push`.
+On `git commit`, `ruff check --fix` and `ruff format` run on changed files, plus basic hygiene hooks (trailing whitespace, EOF, YAML/TOML syntax, merge-conflict markers, 500KB file-size cap). On `git push`, the full test suite runs with `-x -m "not slow"` for fast feedback.
 
-Run everything manually with:
+Bypass a hook for WIP/throwaway work:
+
+```bash
+git commit --no-verify
+SKIP=pytest-fast git push
+```
+
+Run everything manually:
 
 ```bash
 pre-commit run --all-files
 ```
 
+For cleaner `git blame` past the bulk reformat commits:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```

--- a/README.md
+++ b/README.md
@@ -168,3 +168,21 @@ Clone voices sourced from [VoxForge Spanish (CIEMPIESS)](https://huggingface.co/
 ## License
 
 MIT
+
+## Contributing
+
+Pre-commit hooks keep the repo formatted and linted on every commit:
+
+```bash
+pip install -e ".[dev]"
+pre-commit install
+```
+
+Now `git commit` runs `ruff check --fix` and `ruff format` on changed files, plus basic hygiene hooks (trailing whitespace, EOF, YAML/TOML syntax, merge-conflict markers, 500KB file-size cap). A pytest smoke hook runs on `git push`.
+
+Run everything manually with:
+
+```bash
+pre-commit run --all-files
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ speed = [
 all = [
     "qwen3-tts-spanish-voices[mlx,mcp,speed]",
 ]
+dev = [
+    "pytest>=7",
+    "ruff>=0.15",
+    "pre-commit>=3",
+]
 
 [project.scripts]
 spanish-tts = "spanish_tts.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,23 @@ spanish-tts = "spanish_tts.cli:cli"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+# E/W pycodestyle, F pyflakes, I isort, UP pyupgrade, B bugbear
+select = ["E", "F", "W", "I", "UP", "B"]
+# Noise we don't want: long lines (format handles most; keep E501 off for now)
+# and unused module imports inside __init__ (we use them as re-exports).
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/spanish_tts/__init__.py" = ["F401"]
+"tests/**" = ["B011"]  # pytest asserts
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ all = [
 ]
 dev = [
     "pytest>=7",
-    "ruff>=0.15",
+    # Pin to track the ruff-pre-commit hook rev so the same rules run
+    # locally, in the hook, and in CI. Bump both in lockstep.
+    "ruff==0.15.*",
     "pre-commit>=3",
 ]
 
@@ -53,13 +55,13 @@ src = ["src", "tests"]
 [tool.ruff.lint]
 # E/W pycodestyle, F pyflakes, I isort, UP pyupgrade, B bugbear
 select = ["E", "F", "W", "I", "UP", "B"]
-# Noise we don't want: long lines (format handles most; keep E501 off for now)
-# and unused module imports inside __init__ (we use them as re-exports).
+# Long lines: ruff-format handles most cases; leaving E501 off avoids
+# noise on unsplittable strings, URLs, and long comments.
 ignore = ["E501"]
 
 [tool.ruff.lint.per-file-ignores]
+# __init__.py uses imports as re-exports; silence the unused-import lint.
 "src/spanish_tts/__init__.py" = ["F401"]
-"tests/**" = ["B011"]  # pytest asserts
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,14 @@ spanish-tts = "spanish_tts.cli:cli"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.pytest.ini_options]
+# Register custom markers so pytest does not warn with PytestUnknownMarkWarning.
+# CI and the pre-push hook filter with -m "not slow" to skip tests that
+# require heavy extras (mlx, large model downloads, or long audio synthesis).
+markers = [
+    "slow: heavy tests that need the [mlx] extra or long synthesis runs (skipped in CI and pre-push pytest)",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/scripts/curate.py
+++ b/scripts/curate.py
@@ -11,15 +11,12 @@ Usage:
 """
 
 import json
-import os
-import sys
 from collections import Counter, defaultdict
 from pathlib import Path
 
 import click
 import numpy as np
 import soundfile as sf
-
 
 DATASET_ID = "ciempiess/voxforge_spanish"
 
@@ -36,9 +33,9 @@ def _matches_filter(row, country=None, gender=None):
 def _find_speaker_clips(ds, speaker_id, min_duration, max_duration):
     """Find clips for a speaker within duration range."""
     return [
-        (i, row) for i, row in enumerate(ds)
-        if row["speaker_id"] == speaker_id
-        and min_duration <= row["duration"] <= max_duration
+        (i, row)
+        for i, row in enumerate(ds)
+        if row["speaker_id"] == speaker_id and min_duration <= row["duration"] <= max_duration
     ]
 
 
@@ -50,15 +47,17 @@ def _score_speakers(speakers):
         avg_dur = sum(c["duration"] for c in clips) / n_clips
         avg_text_len = sum(len(c["text"]) for c in clips) / n_clips
         best = max(clips, key=lambda c: len(c["text"]) * c["duration"])
-        scored.append({
-            "speaker_id": speaker_id,
-            "n_clips": n_clips,
-            "avg_duration": avg_dur,
-            "avg_text_len": avg_text_len,
-            "best_clip": best,
-            "country": clips[0]["country"],
-            "gender": clips[0]["gender"],
-        })
+        scored.append(
+            {
+                "speaker_id": speaker_id,
+                "n_clips": n_clips,
+                "avg_duration": avg_dur,
+                "avg_text_len": avg_text_len,
+                "best_clip": best,
+                "country": clips[0]["country"],
+                "gender": clips[0]["gender"],
+            }
+        )
     scored.sort(key=lambda s: (s["n_clips"], s["avg_text_len"]), reverse=True)
     return scored
 
@@ -66,6 +65,7 @@ def _score_speakers(speakers):
 def _load_dataset(with_audio=True):
     """Load VoxForge Spanish dataset (cached after first download)."""
     from datasets import load_dataset
+
     click.echo("Loading VoxForge Spanish dataset (3.4 GB, cached after first download)...")
     ds = load_dataset(DATASET_ID, split="train")
     if not with_audio:
@@ -77,6 +77,7 @@ def _load_dataset(with_audio=True):
 def _load_dataset_raw():
     """Load dataset in arrow format for raw audio bytes (bypass torchcodec)."""
     from datasets import load_dataset
+
     click.echo("Loading dataset with raw audio...")
     ds = load_dataset(DATASET_ID, split="train")
     return ds.with_format("arrow")
@@ -85,6 +86,7 @@ def _load_dataset_raw():
 def _decode_audio(ds_raw, idx):
     """Decode audio from raw arrow dataset using soundfile."""
     import io
+
     row = ds_raw[idx]
     audio_bytes = row.column("audio")[0].as_py()["bytes"]
     audio_array, sr = sf.read(io.BytesIO(audio_bytes))
@@ -126,7 +128,9 @@ def browse():
 
 
 @cli.command()
-@click.option("--country", default=None, help="Filter by country (mexico, spain, argentina, chile).")
+@click.option(
+    "--country", default=None, help="Filter by country (mexico, spain, argentina, chile)."
+)
 @click.option("--gender", default=None, type=click.Choice(["male", "female"]))
 @click.option("--min-duration", default=6.0, type=float, help="Minimum clip duration in seconds.")
 @click.option("--max-duration", default=12.0, type=float, help="Maximum clip duration in seconds.")
@@ -146,14 +150,16 @@ def pick(country, gender, min_duration, max_duration, limit):
             continue
         dur = row["duration"]
         if min_duration <= dur <= max_duration:
-            speakers[row["speaker_id"]].append({
-                "index": i,
-                "duration": dur,
-                "text": row["normalized_text"],
-                "country": row["country"],
-                "gender": row["gender"],
-                "audio_id": row["audio_id"],
-            })
+            speakers[row["speaker_id"]].append(
+                {
+                    "index": i,
+                    "duration": dur,
+                    "text": row["normalized_text"],
+                    "country": row["country"],
+                    "gender": row["gender"],
+                    "audio_id": row["audio_id"],
+                }
+            )
 
     if not speakers:
         click.echo("No speakers found matching criteria.")
@@ -162,7 +168,9 @@ def pick(country, gender, min_duration, max_duration, limit):
     scored = _score_speakers(speakers)
 
     click.echo(f"\nTop {limit} candidates ({country or 'any'}, {gender or 'any'}):")
-    click.echo(f"{'SPEAKER':<14} {'COUNTRY':<14} {'CLIPS':<7} {'AVG_DUR':<9} {'BEST_DUR':<10} {'BEST_TEXT'}")
+    click.echo(
+        f"{'SPEAKER':<14} {'COUNTRY':<14} {'CLIPS':<7} {'AVG_DUR':<9} {'BEST_DUR':<10} {'BEST_TEXT'}"
+    )
     click.echo("-" * 100)
     for s in scored[:limit]:
         best = s["best_clip"]
@@ -182,8 +190,12 @@ def pick(country, gender, min_duration, max_duration, limit):
 @cli.command()
 @click.argument("speaker_id")
 @click.option("--name", required=True, help="Voice name for the registry (e.g. carlos_mx).")
-@click.option("--clip-index", default=None, type=int,
-              help="Specific dataset index. If not given, picks the best clip.")
+@click.option(
+    "--clip-index",
+    default=None,
+    type=int,
+    help="Specific dataset index. If not given, picks the best clip.",
+)
 @click.option("--min-duration", default=6.0, type=float)
 @click.option("--max-duration", default=12.0, type=float)
 def export(speaker_id, name, clip_index, min_duration, max_duration):
@@ -194,7 +206,9 @@ def export(speaker_id, name, clip_index, min_duration, max_duration):
         # Use specific clip
         row = ds_meta[clip_index]
         if row["speaker_id"] != speaker_id:
-            click.echo(f"Warning: index {clip_index} belongs to {row['speaker_id']}, not {speaker_id}")
+            click.echo(
+                f"Warning: index {clip_index} belongs to {row['speaker_id']}, not {speaker_id}"
+            )
         best_idx = clip_index
         meta = row
     else:
@@ -206,7 +220,9 @@ def export(speaker_id, name, clip_index, min_duration, max_duration):
             return
 
         # Pick longest text within duration range
-        best_idx, meta = max(candidates, key=lambda x: len(x[1]["normalized_text"]) * x[1]["duration"])
+        best_idx, meta = max(
+            candidates, key=lambda x: len(x[1]["normalized_text"]) * x[1]["duration"]
+        )
         click.echo(f"Selected clip index {best_idx}: {meta['duration']:.1f}s")
 
     # Extract audio via raw bytes
@@ -238,7 +254,7 @@ def export(speaker_id, name, clip_index, min_duration, max_duration):
     click.echo(f"  Text:    {meta['normalized_text']}")
     click.echo(f"  Country: {meta['country']}")
     click.echo(f"  Gender:  {meta['gender']}")
-    click.echo(f"\nUse: spanish-tts say \"Hola mundo\" --voice {name}")
+    click.echo(f'\nUse: spanish-tts say "Hola mundo" --voice {name}')
 
 
 @cli.command("listen")
@@ -269,9 +285,9 @@ def listen(speaker_id, limit, min_duration, max_duration):
 
     for j, (idx, meta) in enumerate(candidates):
         audio_array, sr = _decode_audio(ds_full, idx)
-        out_path = out_dir / f"{j+1}_{meta['audio_id']}.wav"
+        out_path = out_dir / f"{j + 1}_{meta['audio_id']}.wav"
         sf.write(str(out_path), audio_array, sr)
-        click.echo(f"  [{j+1}] {out_path}")
+        click.echo(f"  [{j + 1}] {out_path}")
         click.echo(f"      {meta['duration']:.1f}s: {meta['normalized_text'][:80]}")
 
     click.echo(f"\nPreview: afplay {out_dir}/1_*.wav")

--- a/scripts/prototype_speed_fix.py
+++ b/scripts/prototype_speed_fix.py
@@ -11,15 +11,16 @@ This confirms the approach is viable before an agent ports it into
 src/spanish_tts/engine.py.
 """
 
-import sys, time
+import sys
+import time
 from pathlib import Path
+
+import librosa
 import numpy as np
 import soundfile as sf
-import librosa
 
 from spanish_tts.config import get_voice
-from spanish_tts.engine import generate, _get_model, MODELS
-
+from spanish_tts.engine import MODELS, _get_model, generate
 
 SAMPLE_TEXT = "El rápido zorro marrón salta sobre el perro perezoso."
 OUT_DIR = Path("/tmp/spanish-tts-prototype")
@@ -46,8 +47,7 @@ def synth_and_stretch(voice_name: str, text: str, speed: float, tag: str) -> dic
 
     t0 = time.time()
     if not base_path.exists():
-        generate(text=text, voice_config=voice_cfg, speed=1.0,
-                 output=str(base_path))
+        generate(text=text, voice_config=voice_cfg, speed=1.0, output=str(base_path))
     gen_time = time.time() - t0
 
     audio, sr = sf.read(str(base_path))
@@ -57,10 +57,15 @@ def synth_and_stretch(voice_name: str, text: str, speed: float, tag: str) -> dic
 
     sf.write(str(stretched_path), stretched, sr)
     dur = len(stretched) / sr
-    return {"voice": voice_name, "speed": speed, "path": str(stretched_path),
-            "duration_s": round(dur, 3), "samples": len(stretched),
-            "gen_time_s": round(gen_time, 2),
-            "stretch_time_ms": round(stretch_time * 1000, 1)}
+    return {
+        "voice": voice_name,
+        "speed": speed,
+        "path": str(stretched_path),
+        "duration_s": round(dur, 3),
+        "samples": len(stretched),
+        "gen_time_s": round(gen_time, 2),
+        "stretch_time_ms": round(stretch_time * 1000, 1),
+    }
 
 
 def spectral_centroid_hz(path: str) -> float:
@@ -77,10 +82,12 @@ def run_matrix():
     print("\n--- neutral_male (design) speed sweep ---")
     design_runs = {}
     for spd in [0.5, 1.0, 1.0, 2.0]:
-        r = synth_and_stretch("neutral_male", SAMPLE_TEXT, spd, f"nm")
+        r = synth_and_stretch("neutral_male", SAMPLE_TEXT, spd, "nm")
         design_runs.setdefault(spd, []).append(r)
-        print(f"  speed={spd:.2f}  dur={r['duration_s']:>5}s  "
-              f"stretch={r['stretch_time_ms']}ms  gen={r['gen_time_s']}s")
+        print(
+            f"  speed={spd:.2f}  dur={r['duration_s']:>5}s  "
+            f"stretch={r['stretch_time_ms']}ms  gen={r['gen_time_s']}s"
+        )
 
     d05 = design_runs[0.5][0]["duration_s"]
     d10_a = design_runs[1.0][0]["duration_s"]
@@ -91,21 +98,25 @@ def run_matrix():
     r_fast = d20 / d10_a
     var_10 = abs(d10_a - d10_b) / max(d10_a, d10_b)
 
-    results["test2_slow_ratio"] = {"value": round(r_slow,3), "pass": 1.7 <= r_slow <= 2.3}
-    results["test3_fast_ratio"] = {"value": round(r_fast,3), "pass": 0.45 <= r_fast <= 0.55}
-    results["test5_variance"]   = {"value": round(var_10,4), "pass": var_10 < 0.05}
+    results["test2_slow_ratio"] = {"value": round(r_slow, 3), "pass": 1.7 <= r_slow <= 2.3}
+    results["test3_fast_ratio"] = {"value": round(r_fast, 3), "pass": 0.45 <= r_fast <= 0.55}
+    results["test5_variance"] = {"value": round(var_10, 4), "pass": var_10 < 0.05}
 
     c05 = spectral_centroid_hz(design_runs[0.5][0]["path"])
     c10 = spectral_centroid_hz(design_runs[1.0][0]["path"])
     c20 = spectral_centroid_hz(design_runs[2.0][0]["path"])
     results["test11_pitch_slow"] = {
-        "c_slow": round(c05,1), "c_ref": round(c10,1),
-        "pct_diff": round(abs(c05-c10)/c10*100,1),
-        "pass": abs(c05-c10)/c10 < 0.15}
+        "c_slow": round(c05, 1),
+        "c_ref": round(c10, 1),
+        "pct_diff": round(abs(c05 - c10) / c10 * 100, 1),
+        "pass": abs(c05 - c10) / c10 < 0.15,
+    }
     results["test11_pitch_fast"] = {
-        "c_fast": round(c20,1), "c_ref": round(c10,1),
-        "pct_diff": round(abs(c20-c10)/c10*100,1),
-        "pass": abs(c20-c10)/c10 < 0.15}
+        "c_fast": round(c20, 1),
+        "c_ref": round(c10, 1),
+        "pct_diff": round(abs(c20 - c10) / c10 * 100, 1),
+        "pass": abs(c20 - c10) / c10 < 0.15,
+    }
 
     print("\n--- carlos_mx (clone) sanity check ---")
     _get_model(MODELS["clone"])
@@ -116,8 +127,14 @@ def run_matrix():
     r_clone_fast = clone_fast["duration_s"] / clone_base["duration_s"]
     print(f"  clone 0.5/1.0 ratio = {r_clone_slow:.3f}")
     print(f"  clone 2.0/1.0 ratio = {r_clone_fast:.3f}")
-    results["test4_clone_slow"] = {"value": round(r_clone_slow,3), "pass": 1.7 <= r_clone_slow <= 2.3}
-    results["test4_clone_fast"] = {"value": round(r_clone_fast,3), "pass": 0.45 <= r_clone_fast <= 0.55}
+    results["test4_clone_slow"] = {
+        "value": round(r_clone_slow, 3),
+        "pass": 1.7 <= r_clone_slow <= 2.3,
+    }
+    results["test4_clone_fast"] = {
+        "value": round(r_clone_fast, 3),
+        "pass": 0.45 <= r_clone_fast <= 0.55,
+    }
 
     errors = []
     for bad in [0.499, 2.001, 0.4, 2.5]:
@@ -132,9 +149,11 @@ def run_matrix():
             errors.append((ok, "ACCEPTED"))
         except ValueError as e:
             errors.append((ok, f"REJECTED (bug): {e}"))
-    results["test12_boundaries"] = {"cases": errors,
-        "pass": all(("ACCEPTED" in str(x[1])) for x in errors if x[0] in (0.5,2.0))
-              and all(("out of range" in str(x[1])) for x in errors if x[0] not in (0.5,2.0))}
+    results["test12_boundaries"] = {
+        "cases": errors,
+        "pass": all(("ACCEPTED" in str(x[1])) for x in errors if x[0] in (0.5, 2.0))
+        and all(("out of range" in str(x[1])) for x in errors if x[0] not in (0.5, 2.0)),
+    }
 
     print("\n=== RESULTS ===")
     for name, r in results.items():

--- a/src/spanish_tts/__init__.py
+++ b/src/spanish_tts/__init__.py
@@ -1,2 +1,3 @@
 """spanish-tts: Curated Spanish TTS voices using Qwen3-TTS."""
+
 __version__ = "0.1.0"

--- a/src/spanish_tts/cli.py
+++ b/src/spanish_tts/cli.py
@@ -9,7 +9,7 @@ from spanish_tts.config import (
     get_voice,
     list_voices,
 )
-from spanish_tts.engine import generate, SPEED_MIN, SPEED_MAX
+from spanish_tts.engine import SPEED_MAX, SPEED_MIN, generate
 
 
 @click.group()
@@ -22,7 +22,13 @@ def cli():
 @cli.command()
 @click.argument("text")
 @click.option("--voice", "-v", default="neutral_male", help="Voice name from registry.")
-@click.option("--speed", "-s", type=click.FloatRange(SPEED_MIN, SPEED_MAX), default=None, help="Speed factor (0.5-2.0).")
+@click.option(
+    "--speed",
+    "-s",
+    type=click.FloatRange(SPEED_MIN, SPEED_MAX),
+    default=None,
+    help="Speed factor (0.5-2.0).",
+)
 @click.option("--output", "-o", default=None, help="Output .wav path.")
 @click.option("--play", "-p", is_flag=True, help="Auto-play with afplay after generating.")
 def say(text, voice, speed, output, play):
@@ -51,6 +57,7 @@ def say(text, voice, speed, output, play):
 
     if play:
         import subprocess
+
         subprocess.run(["afplay", result])
 
 
@@ -132,6 +139,7 @@ def voices():
 def remove(name):
     """Remove a voice from the registry."""
     from spanish_tts.config import load_voices, save_voices
+
     data = load_voices()
     voices = data.get("voices", {})
     if name not in voices:
@@ -145,11 +153,20 @@ def remove(name):
 
 @cli.command()
 @click.argument("text")
-@click.option("--output-dir", "-d", default="/tmp/spanish-tts-demo", help="Directory for demo files.")
-@click.option("--speed", "-s", type=click.FloatRange(SPEED_MIN, SPEED_MAX), default=1.0, help="Speed factor (0.5-2.0).")
+@click.option(
+    "--output-dir", "-d", default="/tmp/spanish-tts-demo", help="Directory for demo files."
+)
+@click.option(
+    "--speed",
+    "-s",
+    type=click.FloatRange(SPEED_MIN, SPEED_MAX),
+    default=1.0,
+    help="Speed factor (0.5-2.0).",
+)
 def demo(text, output_dir, speed):
     """Generate the same text with ALL registered voices for comparison."""
     from pathlib import Path
+
     voices = list_voices()
     if not voices:
         click.echo("No voices registered.")

--- a/src/spanish_tts/config.py
+++ b/src/spanish_tts/config.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import yaml
 
-
 VOICES_FILENAME = "voices.yaml"
 DEFAULT_CONFIG_DIR = Path.home() / ".spanish-tts"
 DEFAULT_VOICES_FILE = Path(__file__).parent.parent.parent / "presets" / VOICES_FILENAME
@@ -77,4 +76,6 @@ def list_voices(voices_file: Path | None = None) -> dict[str, dict[str, Any]]:
 def get_defaults(voices_file: Path | None = None) -> dict[str, Any]:
     """Get default settings."""
     data = load_voices(voices_file)
-    return data.get("defaults", {"language": "Spanish", "speed": 1.0, "output_dir": "~/tts-output/spanish"})
+    return data.get(
+        "defaults", {"language": "Spanish", "speed": 1.0, "output_dir": "~/tts-output/spanish"}
+    )

--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -1,7 +1,6 @@
 """TTS engine wrapping Qwen3-TTS MLX for clone and design modes."""
 
 import logging
-import os
 import sys
 from collections.abc import Callable
 from datetime import datetime
@@ -54,9 +53,7 @@ def _apply_speed(audio: np.ndarray, speed: float, sample_rate: int) -> np.ndarra
 
     # Input contract: mono 1-D numpy array, non-empty, finite samples.
     if not isinstance(audio, np.ndarray):
-        raise ValueError(
-            f"_apply_speed expects numpy.ndarray, got {type(audio).__name__}"
-        )
+        raise ValueError(f"_apply_speed expects numpy.ndarray, got {type(audio).__name__}")
     if audio.ndim != 1:
         raise ValueError(
             f"_apply_speed expects mono 1-D audio, got shape {audio.shape}. "
@@ -85,7 +82,9 @@ def _apply_speed(audio: np.ndarray, speed: float, sample_rate: int) -> np.ndarra
     try:
         import librosa
     except ImportError:
-        logger.warning("librosa not installed; speed parameter ignored. Install with: pip install 'spanish-tts[speed]'")
+        logger.warning(
+            "librosa not installed; speed parameter ignored. Install with: pip install 'spanish-tts[speed]'"
+        )
         return audio
 
     stretched = librosa.effects.time_stretch(y=audio_f, rate=speed)
@@ -96,6 +95,7 @@ def _get_model(model_id: str):
     """Load MLX model with caching."""
     if model_id not in _model_cache:
         from mlx_audio.tts import load_model
+
         print(f"Loading model: {model_id}", file=sys.stderr)
         _model_cache[model_id] = load_model(model_id)
     return _model_cache[model_id]
@@ -114,8 +114,9 @@ def _resolve_output(output: str | None, prefix: str, output_dir: str | None = No
     return str(out_dir / f"{prefix}_{ts}.wav")
 
 
-def _collect_audio(results, stream: bool,
-                   on_chunk: Callable[[int, int, float], None] | None = None):
+def _collect_audio(
+    results, stream: bool, on_chunk: Callable[[int, int, float], None] | None = None
+):
     """Collect audio from a generator of GenerationResults.
 
     When stream=False, takes the first result (non-streaming behavior).
@@ -179,8 +180,7 @@ def generate_clone(
     if not ref_path.exists():
         raise FileNotFoundError(f"Reference audio not found: {ref_path}")
 
-    print(f"Cloning voice from: {ref_path}" + (" [streaming]" if stream else ""),
-          file=sys.stderr)
+    print(f"Cloning voice from: {ref_path}" + (" [streaming]" if stream else ""), file=sys.stderr)
     results = model.generate(
         text=text,
         lang_code="auto",
@@ -235,15 +235,24 @@ def generate_design(
     model = _get_model(model_id or MODELS["design"])
 
     lang_map = {
-        "Spanish": "spanish", "English": "english", "Chinese": "chinese",
-        "French": "french", "German": "german", "Italian": "italian",
-        "Portuguese": "portuguese", "Japanese": "japanese", "Korean": "korean",
+        "Spanish": "spanish",
+        "English": "english",
+        "Chinese": "chinese",
+        "French": "french",
+        "German": "german",
+        "Italian": "italian",
+        "Portuguese": "portuguese",
+        "Japanese": "japanese",
+        "Korean": "korean",
         "Russian": "russian",
     }
     lang_code = lang_map.get(language, "spanish")
 
-    print(f"Designing voice: '{instruct[:60]}...' (lang={lang_code})"
-          + (" [streaming]" if stream else ""), file=sys.stderr)
+    print(
+        f"Designing voice: '{instruct[:60]}...' (lang={lang_code})"
+        + (" [streaming]" if stream else ""),
+        file=sys.stderr,
+    )
     results = model.generate(
         text=text,
         lang_code=lang_code,

--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -19,7 +19,7 @@ import sys
 from mcp.server.fastmcp import FastMCP
 
 from spanish_tts.config import get_defaults, get_voice, list_voices
-from spanish_tts.engine import generate, generate_clone, generate_design
+from spanish_tts.engine import generate
 
 logger = logging.getLogger("spanish-tts-mcp")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,5 @@
 """Tests for spanish_tts.config module."""
 
-import tempfile
-from pathlib import Path
-
 import pytest
 import yaml
 

--- a/tests/test_curate.py
+++ b/tests/test_curate.py
@@ -57,11 +57,29 @@ class TestScoreSpeakers:
     def speakers(self):
         return {
             "SPK001": [
-                {"duration": 8.0, "text": "Primera oracion corta", "country": "Mexico", "gender": "male", "audio_id": "a1"},
-                {"duration": 7.5, "text": "Segunda oracion un poco mas larga que la primera", "country": "Mexico", "gender": "male", "audio_id": "a2"},
+                {
+                    "duration": 8.0,
+                    "text": "Primera oracion corta",
+                    "country": "Mexico",
+                    "gender": "male",
+                    "audio_id": "a1",
+                },
+                {
+                    "duration": 7.5,
+                    "text": "Segunda oracion un poco mas larga que la primera",
+                    "country": "Mexico",
+                    "gender": "male",
+                    "audio_id": "a2",
+                },
             ],
             "SPK002": [
-                {"duration": 9.0, "text": "Una sola oracion", "country": "Spain", "gender": "female", "audio_id": "b1"},
+                {
+                    "duration": 9.0,
+                    "text": "Una sola oracion",
+                    "country": "Spain",
+                    "gender": "female",
+                    "audio_id": "b1",
+                },
             ],
         }
 

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,14 +1,16 @@
 """Speed correctness tests for pitch-preserving time-stretch."""
 
 import logging
-import pytest
-import numpy as np
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-from spanish_tts.engine import _apply_speed, SPEED_MIN, SPEED_MAX
+import numpy as np
+import pytest
+
+from spanish_tts.engine import SPEED_MAX, SPEED_MIN, _apply_speed
 
 try:
     import librosa  # noqa: F401
+
     HAS_LIBROSA = True
 except ImportError:
     HAS_LIBROSA = False
@@ -30,7 +32,8 @@ class TestApplySpeed:
         """speed=0.5 accepted without error."""
         audio = np.zeros(24000, dtype=np.float32)
         try:
-            import librosa
+            import librosa  # noqa: F401  # probe for availability
+
             result = _apply_speed(audio, 0.5, 24000)
             assert result is not None
         except ImportError:
@@ -40,7 +43,8 @@ class TestApplySpeed:
         """speed=2.0 accepted without error."""
         audio = np.zeros(24000, dtype=np.float32)
         try:
-            import librosa
+            import librosa  # noqa: F401  # probe for availability
+
             result = _apply_speed(audio, 2.0, 24000)
             assert result is not None
         except ImportError:
@@ -58,13 +62,10 @@ class TestApplySpeed:
         with pytest.raises(ValueError, match="speed out of range"):
             _apply_speed(audio, 2.001, 24000)
 
-    @pytest.mark.skipif(
-        not HAS_LIBROSA,
-        reason="librosa not available"
-    )
+    @pytest.mark.skipif(not HAS_LIBROSA, reason="librosa not available")
     def test_speed_stretch_ratio_slow(self):
         """speed=0.5 doubles length (±5% tolerance)."""
-        import librosa
+
         # Short synthetic sine wave: 1 second @ 24kHz
         audio = np.sin(2 * np.pi * 440 * np.linspace(0, 1, 24000)).astype(np.float32)
         stretched = _apply_speed(audio, 0.5, 24000)
@@ -72,66 +73,51 @@ class TestApplySpeed:
         ratio = len(stretched) / expected_len
         assert 0.95 <= ratio <= 1.05, f"Slow stretch ratio {ratio} outside 0.95-1.05"
 
-    @pytest.mark.skipif(
-        not HAS_LIBROSA,
-        reason="librosa not available"
-    )
+    @pytest.mark.skipif(not HAS_LIBROSA, reason="librosa not available")
     def test_speed_stretch_ratio_fast(self):
         """speed=2.0 halves length (±5% tolerance)."""
-        import librosa
+
         audio = np.sin(2 * np.pi * 440 * np.linspace(0, 1, 24000)).astype(np.float32)
         stretched = _apply_speed(audio, 2.0, 24000)
         expected_len = len(audio) / 2
         ratio = len(stretched) / expected_len
         assert 0.95 <= ratio <= 1.05, f"Fast stretch ratio {ratio} outside 0.95-1.05"
 
-    @pytest.mark.skipif(
-        not HAS_LIBROSA,
-        reason="librosa not available"
-    )
+    @pytest.mark.skipif(not HAS_LIBROSA, reason="librosa not available")
     def test_pitch_preservation_slow(self):
         """Spectral centroid diff <10% between speed=1.0 and speed=0.5."""
         import librosa
+
         # Synthetic 440Hz sine at 24kHz for 2 seconds
         sr = 24000
         t = np.linspace(0, 2, sr * 2)
         audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
 
         # Compute spectral centroid
-        cent_ref = float(np.mean(librosa.feature.spectral_centroid(
-            y=audio, sr=sr
-        )))
+        cent_ref = float(np.mean(librosa.feature.spectral_centroid(y=audio, sr=sr)))
 
         stretched = _apply_speed(audio, 0.5, sr)
-        cent_slow = float(np.mean(librosa.feature.spectral_centroid(
-            y=stretched, sr=sr
-        )))
+        cent_slow = float(np.mean(librosa.feature.spectral_centroid(y=stretched, sr=sr)))
 
         pct_diff = abs(cent_slow - cent_ref) / cent_ref
-        assert pct_diff < 0.10, f"Pitch drift {pct_diff*100:.1f}% > 10%"
+        assert pct_diff < 0.10, f"Pitch drift {pct_diff * 100:.1f}% > 10%"
 
-    @pytest.mark.skipif(
-        not HAS_LIBROSA,
-        reason="librosa not available"
-    )
+    @pytest.mark.skipif(not HAS_LIBROSA, reason="librosa not available")
     def test_pitch_preservation_fast(self):
         """Spectral centroid diff <10% between speed=1.0 and speed=2.0."""
         import librosa
+
         sr = 24000
         t = np.linspace(0, 2, sr * 2)
         audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
 
-        cent_ref = float(np.mean(librosa.feature.spectral_centroid(
-            y=audio, sr=sr
-        )))
+        cent_ref = float(np.mean(librosa.feature.spectral_centroid(y=audio, sr=sr)))
 
         stretched = _apply_speed(audio, 2.0, sr)
-        cent_fast = float(np.mean(librosa.feature.spectral_centroid(
-            y=stretched, sr=sr
-        )))
+        cent_fast = float(np.mean(librosa.feature.spectral_centroid(y=stretched, sr=sr)))
 
         pct_diff = abs(cent_fast - cent_ref) / cent_ref
-        assert pct_diff < 0.10, f"Pitch drift {pct_diff*100:.1f}% > 10%"
+        assert pct_diff < 0.10, f"Pitch drift {pct_diff * 100:.1f}% > 10%"
 
     def test_graceful_fallback_no_librosa(self):
         """Missing librosa returns input unchanged with warning."""
@@ -145,8 +131,8 @@ class TestApplySpeed:
                     # Contract: fallback must log a warning, not fail silently.
                     mock_logger.warning.assert_called_once()
                     msg = mock_logger.warning.call_args[0][0]
-                    assert 'librosa' in msg.lower()
-                    assert 'speed' in msg.lower()
+                    assert "librosa" in msg.lower()
+                    assert "speed" in msg.lower()
 
 
 class TestCLISpeedValidation:
@@ -155,6 +141,7 @@ class TestCLISpeedValidation:
     def test_cli_speed_reject_out_of_range(self):
         """CLI rejects --speed 3.0 before loading any model."""
         from click.testing import CliRunner
+
         from spanish_tts.cli import cli
 
         runner = CliRunner()
@@ -165,12 +152,15 @@ class TestCLISpeedValidation:
     def test_cli_speed_accept_boundary_min(self):
         """CLI accepts --speed 0.5."""
         from click.testing import CliRunner
+
         from spanish_tts.cli import say
 
         runner = CliRunner()
         # Mock generate to avoid loading model
         with patch("spanish_tts.cli.generate", return_value="/tmp/test.wav"):
-            with patch("spanish_tts.cli.get_voice", return_value={"type": "design", "instruct": "test"}):
+            with patch(
+                "spanish_tts.cli.get_voice", return_value={"type": "design", "instruct": "test"}
+            ):
                 with patch("spanish_tts.cli.get_defaults", return_value={}):
                     result = runner.invoke(say, ["test", "--speed", "0.5"])
                     # Should not error on speed parsing
@@ -179,11 +169,14 @@ class TestCLISpeedValidation:
     def test_cli_speed_accept_boundary_max(self):
         """CLI accepts --speed 2.0."""
         from click.testing import CliRunner
+
         from spanish_tts.cli import say
 
         runner = CliRunner()
         with patch("spanish_tts.cli.generate", return_value="/tmp/test.wav"):
-            with patch("spanish_tts.cli.get_voice", return_value={"type": "design", "instruct": "test"}):
+            with patch(
+                "spanish_tts.cli.get_voice", return_value={"type": "design", "instruct": "test"}
+            ):
                 with patch("spanish_tts.cli.get_defaults", return_value={}):
                     result = runner.invoke(say, ["test", "--speed", "2.0"])
                     assert "out of range" not in result.output.lower() or result.exit_code == 0
@@ -196,18 +189,20 @@ class TestMCPSpeedValidation:
         """MCP say(speed=None) honours voices.yaml defaults.speed (CLI parity)."""
         from spanish_tts.mcp_server import say
 
-        with patch("spanish_tts.mcp_server.get_voice",
-                   return_value={"type": "design", "instruct": "t"}):
-            with patch("spanish_tts.mcp_server.get_defaults",
-                       return_value={"speed": 1.25, "output_dir": "/tmp/x"}):
+        with patch(
+            "spanish_tts.mcp_server.get_voice", return_value={"type": "design", "instruct": "t"}
+        ):
+            with patch(
+                "spanish_tts.mcp_server.get_defaults",
+                return_value={"speed": 1.25, "output_dir": "/tmp/x"},
+            ):
                 captured = {}
 
                 def fake_generate(**kwargs):
                     captured.update(kwargs)
                     return "/tmp/ok.wav"
 
-                with patch("spanish_tts.mcp_server.generate",
-                           side_effect=fake_generate):
+                with patch("spanish_tts.mcp_server.generate", side_effect=fake_generate):
                     result = say(text="hola", voice="x", speed=None)
                     assert "error" not in result
                     assert captured["speed"] == 1.25
@@ -216,33 +211,37 @@ class TestMCPSpeedValidation:
         """MCP say() without speed arg uses defaults (parity with CLI)."""
         from spanish_tts.mcp_server import say
 
-        with patch("spanish_tts.mcp_server.get_voice",
-                   return_value={"type": "design", "instruct": "t"}):
-            with patch("spanish_tts.mcp_server.get_defaults",
-                       return_value={"speed": 0.9, "output_dir": "/tmp/x"}):
+        with patch(
+            "spanish_tts.mcp_server.get_voice", return_value={"type": "design", "instruct": "t"}
+        ):
+            with patch(
+                "spanish_tts.mcp_server.get_defaults",
+                return_value={"speed": 0.9, "output_dir": "/tmp/x"},
+            ):
                 captured = {}
 
                 def fake_generate(**kwargs):
                     captured.update(kwargs)
                     return "/tmp/ok.wav"
 
-                with patch("spanish_tts.mcp_server.generate",
-                           side_effect=fake_generate):
-                    result = say(text="hola", voice="x")
+                with patch("spanish_tts.mcp_server.generate", side_effect=fake_generate):
+                    say(text="hola", voice="x")
                     assert captured["speed"] == 0.9
 
     def test_mcp_say_defaults_speed_out_of_range_rejected(self):
         """MCP say() rejects out-of-range defaults.speed after fallback."""
         from spanish_tts.mcp_server import say
 
-        with patch("spanish_tts.mcp_server.get_voice",
-                   return_value={"type": "design", "instruct": "t"}):
-            with patch("spanish_tts.mcp_server.get_defaults",
-                       return_value={"speed": 3.0, "output_dir": "/tmp/x"}):
+        with patch(
+            "spanish_tts.mcp_server.get_voice", return_value={"type": "design", "instruct": "t"}
+        ):
+            with patch(
+                "spanish_tts.mcp_server.get_defaults",
+                return_value={"speed": 3.0, "output_dir": "/tmp/x"},
+            ):
                 result = say(text="hola", voice="x")
                 assert "error" in result
                 assert "speed out of range" in result["error"]
-
 
     def test_mcp_say_reject_out_of_range(self):
         """MCP say() rejects out-of-range speed."""
@@ -285,6 +284,7 @@ class TestConstants:
         """SPEED_MIN=0.5, SPEED_MAX=2.0."""
         assert SPEED_MIN == 0.5
         assert SPEED_MAX == 2.0
+
 
 class TestApplySpeedInputGuards:
     """ENG-1: _apply_speed input-contract guards."""
@@ -357,4 +357,3 @@ class TestApplySpeedInputGuards:
         audio = np.zeros(2047, dtype=np.float32)
         with pytest.raises(ValueError, match="at least"):
             _apply_speed(audio, 1.5, 24000)
-


### PR DESCRIPTION
## WHY

ATOMIC-COMMIT DISCIPLINE IS CURRENTLY MANUAL AGENT EFFORT. A
PRE-COMMIT HOOK SUITE KEEPS FUTURE PRs CLEAN WITHOUT ANYONE
(AGENT OR HUMAN) HAVING TO REMEMBER TO RUN THE FORMATTER.

## WHAT (FOUR ATOMIC COMMITS)

1. `build(ruff)` — ADD `[tool.ruff]` CONFIG TO `pyproject.toml`:
   - line-length 100, target py311, src=[src,tests]
   - lint: E,F,W,I,UP,B with E501 OFF (format handles width)
   - per-file: F401 off for `src/spanish_tts/__init__.py`
     (module re-exports), B011 off for `tests/**` (pytest asserts)
   - format: double-quote, space indent

2. `style` — BULK REFORMAT src/ AND tests/:
   - `ruff format` applied to 6 files
   - `ruff check --fix` applied 14 auto-fixes (I001 import
     sorting, UP pyupgrade, B bugbear)
   - two `import librosa` availability probes in tests get
     `# noqa: F401  # probe for availability`
   - one unused `result = say(...)` drop (F841)
   - 84/84 tests still pass

3. `style(scripts)` — BULK REFORMAT scripts/ (curate.py,
   prototype_speed_fix.py). Caught by pre-commit on
   --all-files; kept as a separate bisect-friendly commit.

4. `build(dev)` — THE ACTUAL FEATURE:
   - `.pre-commit-config.yaml`: ruff check + format, plus
     pre-commit-hooks (trailing-whitespace, EOF, check-yaml,
     check-toml, check-added-large-files 500KB, check-merge-
     conflict), plus a local `pytest-changed` hook scoped to
     pre-push only (fast commits, real CI on push)
   - `pyproject.toml` new `[dev]` extra: pytest, ruff, pre-commit
   - `README.md` new "Contributing" section

## TEST

```
conda run -n qwen3-tts pre-commit run --all-files    # all hooks pass
conda run -n qwen3-tts python -m pytest -q           # 84 passed
```

## ONBOARDING

```bash
pip install -e ".[dev]"
pre-commit install           # installs commit hook
pre-commit install --hook-type pre-push   # installs pre-push pytest hook
```

## RISK / ROLLBACK

- Four commits, each bisectable. A revert of commit 4 alone
  disables the hooks but leaves the formatting and config in
  place. Reverting commits 2+3 alone restores unformatted
  code (noisy diff, nothing functional).
- No runtime dependency change. `ruff` and `pre-commit` live
  in the `[dev]` extra only.
- 84/84 tests still passing.

CLOSES CHECKBOX DEV-1 IN #2.
