### PR TITLE
fix(mcp): M4 RETURN FULL INSTRUCT FROM list_all_voices

### DIFF
--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -111,8 +111,12 @@ def list_all_voices() -> dict:
             if config.get("type") == "clone":
                 summary[name]["accent"] = config.get("accent", "")
             elif config.get("type") == "design":
-                instruct = config.get("instruct", "")
-                summary[name]["description"] = instruct[:80]
+                # Return the full instruct prompt. Truncating silently
+                # destroys the persona description — presets ship with
+                # 99-121 char instructs and clipping at 80 drops the
+                # trailing clause (tone/pacing/style) that defines the
+                # voice. Token cost is negligible; 4 presets total.
+                summary[name]["description"] = config.get("instruct", "")
         return {"voices": summary}
     except Exception as e:
         logger.error("list_voices() failed: %s", e, exc_info=True)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,51 @@
+"""Tests for MCP server tool behaviour."""
+
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def bundled_presets(tmp_path, monkeypatch):
+    """Point SPANISH_TTS_CONFIG at an empty dir so load_voices() falls back
+    to the bundled presets/voices.yaml (4 design + any clone presets).
+    Reloads modules so they pick up the new env-driven config dir.
+    """
+    monkeypatch.setenv("SPANISH_TTS_CONFIG", str(tmp_path))
+    # Drop cached modules so they re-read the env var.
+    for mod in ("spanish_tts.config", "spanish_tts.mcp_server"):
+        sys.modules.pop(mod, None)
+    import spanish_tts.config  # noqa: F401
+    import spanish_tts.mcp_server as mcp_server
+    importlib.reload(mcp_server)
+    yield mcp_server
+    for mod in ("spanish_tts.config", "spanish_tts.mcp_server"):
+        sys.modules.pop(mod, None)
+
+
+def test_list_all_voices_returns_full_instruct(bundled_presets):
+    """Design voices should return their complete instruct string,
+    not a silent 80-char truncation. Regression test for M4.
+
+    Bundled presets ship instructs in the 99-121 char range; clipping
+    at 80 drops the trailing tone/pacing clause that defines the voice.
+    """
+    result = bundled_presets.list_all_voices()
+    assert "voices" in result, result
+    voices = result["voices"]
+
+    expected = (
+        "Hombre hispanohablante de 35 años con acento neutro y claro. "
+        "Voz calmada y articulada, como un narrador profesional."
+    )
+    assert "neutral_male" in voices
+    assert voices["neutral_male"]["type"] == "design"
+    assert voices["neutral_male"]["description"] == expected
+    assert len(voices["neutral_male"]["description"]) > 80
+
+    # Every bundled design voice should come through unclipped.
+    for name, info in voices.items():
+        if info.get("type") == "design":
+            assert "description" in info
+            assert info["description"], f"{name} has empty description"


### PR DESCRIPTION
## WHY

MCP `list_all_voices` was silently clipping the `instruct` field at
80 chars with no ellipsis and no `truncated` flag. All 4 bundled
design presets ship instructs in the 99-121 char range, so the clip
was dropping the trailing tone/pacing clause that actually defines
each voice. Agents consuming this tool saw half a persona.

## WHAT

Single commit.

- `src/spanish_tts/mcp_server.py::list_all_voices`: return
  `config.get("instruct", "")` verbatim instead of `instruct[:80]`.
  Comment explains why truncation is wrong for this field.
- `tests/test_mcp_server.py` (new): asserts `neutral_male` comes back
  intact, the description length is >80, and every bundled design
  voice has a non-empty `description`. Uses a tmp
  `SPANISH_TTS_CONFIG` fixture so the test reads bundled presets,
  not user state.

## TEST

```
conda run -n qwen3-tts python -m pytest -q
# 85 passed
```

## RISK / ROLLBACK

Risk: tiny. Callers that rendered `description` just see the full
string. No schema change. No field removed.

Rollback: `git revert <sha>` on main. No data migration required.

CLOSES CHECKBOX M4 IN #2.
