### PR TITLE
ci(workflows): DEV-2 RUFF LINT JOB + DEPENDABOT DEV-TOOLS GROUP

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,12 @@ updates:
       prefix: "build"
     labels:
       - dependencies
+    groups:
+      dev-tools:
+        patterns:
+          - "ruff"
+          - "pytest*"
+          - "pre-commit"
 
   - package-ecosystem: pre-commit
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,25 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff (pinned to match pyproject [dev])
+        run: python -m pip install "ruff==0.15.*"
+
+      - name: ruff check
+        run: ruff check .
+
+      - name: ruff format --check
+        run: ruff format --check .
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,6 +18,7 @@ def bundled_presets(tmp_path, monkeypatch):
         sys.modules.pop(mod, None)
     import spanish_tts.config  # noqa: F401
     import spanish_tts.mcp_server as mcp_server
+
     importlib.reload(mcp_server)
     yield mcp_server
     for mod in ("spanish_tts.config", "spanish_tts.mcp_server"):


### PR DESCRIPTION
## WHY

Pre-commit enforces ruff check + ruff format locally (DEV-1 #9) but
CI only runs pytest. A contributor who skipped pre-commit, or a
dependabot PR that bypasses hooks, could land formatting drift on
main. Caught one today: test_mcp_server.py from #10 had a missing
blank line between import blocks. `pre-commit run` passed locally
but `ruff format --check` flagged it.

Also groups dependabot pip bumps for dev tools into one weekly PR
instead of three, cutting swarm-review overhead.

## WHAT

Two atomic commits.

1. `style(tests): RUFF FORMAT FIX ON test_mcp_server.py` — the
   one-line whitespace fix so CI starts green.
2. `ci(workflows): DEV-2 ADD RUFF LINT JOB FOR PARITY WITH PRE-COMMIT`
   - `.github/workflows/ci.yml`: new `lint` job, ubuntu-latest,
     single Python 3.12, SHA-pinned checkout/setup-python (reuses
     CI-1 pins). Installs `ruff==0.15.*` to match pyproject [dev] and
     .pre-commit-config.yaml `rev`. Runs `ruff check .` and
     `ruff format --check .`.
   - `.github/dependabot.yml`: new `groups.dev-tools` on pip
     ecosystem matching `ruff`, `pytest*`, `pre-commit`.

Deliberate choice: did NOT call `pre-commit run --all-files` in CI —
each hook re-provisions its own venv, ~5× slower than direct ruff.

## TEST

Local parity:
```
conda run -n qwen3-tts ruff check .         # All checks passed!
conda run -n qwen3-tts ruff format --check .  # 15 files already formatted
conda run -n qwen3-tts python -m pytest -q  # 85 passed
```

Lint and test jobs run in parallel. No build-time regression on the
test matrix.

## RISK / ROLLBACK

Risk: low. Lint job is additive; if it flags something real, a
contributor sees it before merge. If ruff 0.15.x ships a new stable
rule, the pinned `0.15.*` range contains it — bump and format
sweep in a follow-up.

Rollback: `git revert <merge-sha>` on main. No data, no schema.

CLOSES CHECKBOX DEV-2 IN #2.
