### PR TITLE
fix(mcp): MCP-1 HARDEN say() AGAINST OUTPUT PATH TRAVERSAL

### DIFF
--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -79,14 +79,36 @@ def say(
     # on purpose: `engine.generate` still accepts arbitrary paths for
     # local-user invocations. Only the MCP tool is sandboxed.
     if output is not None:
+        # Quick structural rejections before touching the filesystem:
+        # empty string, NUL byte (pathlib would raise mid-resolve with
+        # a ValueError that escapes our error-dict contract).
+        if output == "" or "\x00" in output:
+            return {"error": f"output path {output!r} is not a valid filename"}
+
         safe_root = Path(output_dir).expanduser().resolve()
         # Join then resolve so both relative and absolute `output`
-        # values get normalised against the same safe_root.
-        candidate = (
-            (safe_root / output).resolve()
-            if not Path(output).is_absolute()
-            else Path(output).resolve()
-        )
+        # values get normalised against the same safe_root. resolve()
+        # follows symlinks, so a symlink inside safe_root pointing out
+        # is caught by the relative_to check below.
+        try:
+            candidate = (
+                (safe_root / output).resolve()
+                if not Path(output).is_absolute()
+                else Path(output).resolve()
+            )
+        except (OSError, ValueError) as e:
+            return {"error": f"output path {output!r} cannot be resolved: {e}"}
+
+        # Reject writing to safe_root itself — it is a directory and
+        # engine.generate would fail downstream with a less clear error.
+        if candidate == safe_root:
+            return {
+                "error": (
+                    f"output path {output!r} resolves to output_dir "
+                    "itself; supply a filename under it or omit `output`."
+                )
+            }
+
         try:
             candidate.relative_to(safe_root)
         except ValueError:

--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -15,6 +15,7 @@ Hermes config.yaml:
 
 import logging
 import sys
+from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
@@ -41,7 +42,16 @@ def say(
         voice: Voice name from registry (default: neutral_male).
         speed: Speed factor 0.5-2.0. If omitted, falls back to
             voices.yaml `defaults.speed` (or 1.0). Matches CLI behaviour.
-        output: Output .wav path (auto-generated if omitted).
+        output: Output .wav path (auto-generated if omitted). MUST
+            resolve inside the configured output_dir (voices.yaml
+            defaults.output_dir). Absolute paths outside that root and
+            relative ``..`` escapes are rejected — the tool returns an
+            error dict instead of writing. Absolute paths that already
+            resolve inside output_dir are accepted. Hardens the MCP
+            surface for cases where the server is exposed over a
+            transport other than a trusted local stdio parent. CLI
+            users are not affected; they call engine.generate directly
+            and get the untrusted-but-local semantics they always had.
         stream: Use streaming decode for lower memory on long texts (default: false).
 
     Returns:
@@ -62,6 +72,32 @@ def say(
     if not (0.5 <= effective_speed <= 2.0):
         return {"error": f"speed out of range 0.5-2.0: {effective_speed}"}
     output_dir = defaults.get("output_dir", "~/tts-output/spanish")
+
+    # MCP-1 path-traversal hardening. If the caller supplied `output`,
+    # it MUST land inside output_dir once resolved. Rejects absolute
+    # paths and ../../escape attempts. Asymmetric with the CLI path
+    # on purpose: `engine.generate` still accepts arbitrary paths for
+    # local-user invocations. Only the MCP tool is sandboxed.
+    if output is not None:
+        safe_root = Path(output_dir).expanduser().resolve()
+        # Join then resolve so both relative and absolute `output`
+        # values get normalised against the same safe_root.
+        candidate = (
+            (safe_root / output).resolve()
+            if not Path(output).is_absolute()
+            else Path(output).resolve()
+        )
+        try:
+            candidate.relative_to(safe_root)
+        except ValueError:
+            return {
+                "error": (
+                    f"output path {output!r} escapes output_dir "
+                    f"{str(safe_root)!r}. MCP refuses path traversal; "
+                    "use a path relative to output_dir or omit `output`."
+                )
+            }
+        output = str(candidate)
 
     def _on_chunk(idx: int, total_samples: int, est_duration: float) -> None:
         logger.info("Chunk %d: %.1fs generated so far", idx, est_duration)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -50,3 +50,60 @@ def test_list_all_voices_returns_full_instruct(bundled_presets):
         if info.get("type") == "design":
             assert "description" in info
             assert info["description"], f"{name} has empty description"
+
+
+def test_say_rejects_absolute_path_outside_output_dir(bundled_presets, tmp_path, monkeypatch):
+    """MCP-1 regression: absolute paths outside the configured
+    output_dir must be rejected before engine.generate is called.
+    """
+    mcp = bundled_presets
+    # Make sure engine.generate is NEVER reached.
+    monkeypatch.setattr(
+        mcp,
+        "generate",
+        lambda *a, **kw: pytest.fail("generate() must not be called for rejected path"),
+    )
+    # Force defaults.output_dir to a known tmp path.
+    monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+    result = mcp.say(text="hola", voice="neutral_male", output="/etc/passwd")
+    assert "error" in result
+    assert "escapes" in result["error"] or "traversal" in result["error"]
+
+
+def test_say_rejects_dotdot_escape(bundled_presets, tmp_path, monkeypatch):
+    """Relative `../../` escape attempts must also be rejected."""
+    mcp = bundled_presets
+    monkeypatch.setattr(
+        mcp,
+        "generate",
+        lambda *a, **kw: pytest.fail("generate() must not be called for rejected path"),
+    )
+    monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+    result = mcp.say(text="hola", voice="neutral_male", output="../../../etc/passwd")
+    assert "error" in result
+    assert "escapes" in result["error"] or "traversal" in result["error"]
+
+
+def test_say_accepts_relative_path_inside_output_dir(bundled_presets, tmp_path, monkeypatch):
+    """Relative paths that resolve inside output_dir must pass the
+    guard and be handed to engine.generate with an absolute path.
+    """
+    mcp = bundled_presets
+    captured = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return kwargs["output"]
+
+    monkeypatch.setattr(mcp, "generate", fake_generate)
+    monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+    result = mcp.say(text="hola", voice="neutral_male", output="sub/out.wav")
+    # No error returned. The path may or may not exist yet; sf.info
+    # will fail which is fine — `duration_seconds` comes back None.
+    assert "error" not in result, result
+    resolved = captured["output"]
+    assert resolved.startswith(str(tmp_path.resolve()))
+    assert resolved.endswith("sub/out.wav")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -107,3 +107,93 @@ def test_say_accepts_relative_path_inside_output_dir(bundled_presets, tmp_path, 
     resolved = captured["output"]
     assert resolved.startswith(str(tmp_path.resolve()))
     assert resolved.endswith("sub/out.wav")
+
+
+def test_say_rejects_null_byte(bundled_presets, tmp_path, monkeypatch):
+    """Null bytes in output must be rejected structurally, before
+    pathlib resolves them into a ValueError that escapes the tool's
+    error-dict contract.
+    """
+    mcp = bundled_presets
+    monkeypatch.setattr(
+        mcp,
+        "generate",
+        lambda *a, **kw: pytest.fail("generate() must not be called for rejected path"),
+    )
+    monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+    result = mcp.say(text="hola", voice="neutral_male", output="foo\x00.wav")
+    assert "error" in result
+
+
+def test_say_rejects_empty_output_string(bundled_presets, tmp_path, monkeypatch):
+    mcp = bundled_presets
+    monkeypatch.setattr(
+        mcp,
+        "generate",
+        lambda *a, **kw: pytest.fail("generate() must not be called for rejected path"),
+    )
+    monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+    result = mcp.say(text="hola", voice="neutral_male", output="")
+    assert "error" in result
+
+
+def test_say_rejects_symlink_escape(bundled_presets, tmp_path, monkeypatch):
+    """A symlink inside output_dir that points outside the safe root
+    must be caught by resolve()+relative_to(). This is the canonical
+    path-traversal vector that naive os.path.normpath-based guards miss.
+    """
+    outside = tmp_path.parent / "outside-sandbox"
+    outside.mkdir(exist_ok=True)
+    link = tmp_path / "escape_link"
+    link.symlink_to(outside)
+
+    mcp = bundled_presets
+    monkeypatch.setattr(
+        mcp,
+        "generate",
+        lambda *a, **kw: pytest.fail("generate() must not be called for rejected path"),
+    )
+    monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+    result = mcp.say(text="hola", voice="neutral_male", output="escape_link/evil.wav")
+    assert "error" in result
+    assert "escapes" in result["error"]
+
+
+def test_say_accepts_absolute_path_inside_output_dir(bundled_presets, tmp_path, monkeypatch):
+    """Absolute paths that already resolve inside safe_root must be
+    accepted (pins the branch the first batch of tests missed).
+    """
+    mcp = bundled_presets
+    captured = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return kwargs["output"]
+
+    monkeypatch.setattr(mcp, "generate", fake_generate)
+    monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+    target = str(tmp_path.resolve() / "ok.wav")
+    result = mcp.say(text="hola", voice="neutral_male", output=target)
+    assert "error" not in result, result
+    assert captured["output"] == target
+
+
+def test_say_rejects_safe_root_itself(bundled_presets, tmp_path, monkeypatch):
+    """output that resolves to the output_dir itself is a directory,
+    not a filename. Reject with a clear message rather than let
+    engine.generate fail opaquely downstream.
+    """
+    mcp = bundled_presets
+    monkeypatch.setattr(
+        mcp,
+        "generate",
+        lambda *a, **kw: pytest.fail("generate() must not be called for rejected path"),
+    )
+    monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+    result = mcp.say(text="hola", voice="neutral_male", output=".")
+    assert "error" in result


### PR DESCRIPTION
## WHY

MCP tool `say(output=...)` passed the caller string straight to
`engine.generate`. Local stdio MCP is low-risk, but MCP servers get
exposed over other transports. A malicious or confused caller could
write a WAV to `/etc/cron.daily/x.sh` or `../../somewhere`.

## WHAT

Single commit. Harden MCP only — CLI is out of scope by design
(local-user, always trusted).

- `src/spanish_tts/mcp_server.py::say`: if `output` is set, resolve
  it against `voices.yaml defaults.output_dir` and require the
  result to stay inside that safe root. Absolute paths outside the
  root and `../` escapes return an error dict. Paths inside the
  root are accepted and passed to `generate` as a resolved absolute
  path.
- Docstring spells out the asymmetry and the rejection behaviour.

`engine.generate` is unchanged. Tests for CLI callers continue to
pass; only the MCP tool is sandboxed.

## TEST

New tests in `tests/test_mcp_server.py`:

1. Absolute `/etc/passwd` → error dict, `generate` never called.
2. Relative `../../../etc/passwd` → error dict, `generate` never
   called.
3. Relative `sub/out.wav` inside output_dir → accepted, passed to
   `generate` as a resolved absolute path starting with the tmp
   output_dir.

Tests monkeypatch `mcp_server.generate` to `pytest.fail` on call,
verifying the guard without touching MLX.

```
conda run -n qwen3-tts python -m pytest -q
# 88 passed  (was 85)
```

## RISK / ROLLBACK

Risk: low. Only new behaviour is rejection of previously-accepted
out-of-root paths. Anyone relying on that was almost certainly
hitting a bug, but see the `defaults.output_dir` field in
`voices.yaml` to adjust the safe root.

Rollback: `git revert <sha>` on main.

CLOSES CHECKBOX MCP-1 IN #2.
