### PR TITLE
feat(config): M5 WARN ON add_voice OVERWRITE, LOUD ON TYPE CHANGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ scripts/curate.py export --voice warm_female_mx ...
 The bundled preset remains available under its original name; your clone lives under
 the suffixed name.
 
+If you want an error instead of a warning when a collision occurs, pass
+`allow_overwrite=False` to `add_voice()` — it raises a `ValueError` immediately.
+
 ## Architecture
 
 ```text

--- a/README.md
+++ b/README.md
@@ -124,6 +124,27 @@ spanish-tts add-design profesor \
   --gender male
 ```
 
+
+### Name collision warning
+
+`scripts/curate.py export` registers the exported voice under whatever name you supply
+with `--voice`. If you pass the same name as a bundled preset (`neutral_female`,
+`warm_female`, `neutral_male`, `energetic_male`), the preset will be overwritten in
+your local registry and `add_voice` will emit a **WARNING** in the logs. If the types
+differ (e.g. preset is `design`, your export is `clone`) the warning is louder and
+suggests a suffix name.
+
+To avoid the collision, suffix your voice names with a regional hint:
+
+```bash
+# Instead of: scripts/curate.py export --voice warm_female ...
+scripts/curate.py export --voice warm_female_es ...
+scripts/curate.py export --voice warm_female_mx ...
+```
+
+The bundled preset remains available under its original name; your clone lives under
+the suffixed name.
+
 ## Architecture
 
 ```text

--- a/presets/voices.yaml
+++ b/presets/voices.yaml
@@ -1,5 +1,11 @@
 # Voice registry for spanish-tts
 # Each voice is either 'clone' (from reference audio) or 'design' (from description)
+#
+# NAME COLLISION WARNING: if you export a curate.py clone under the same name as one
+# of the preset voices below (neutral_female, warm_female, neutral_male,
+# energetic_male), add_voice() will log a WARNING and overwrite the preset in your
+# local registry. To avoid this, suffix your clone names with a regional hint, e.g.
+# warm_female_es or neutral_female_mx.
 
 voices:
   # === Clone voices (from VoxForge Spanish corpus) ===

--- a/src/spanish_tts/config.py
+++ b/src/spanish_tts/config.py
@@ -73,8 +73,9 @@ def add_voice(
     overwriting. If the existing entry has a different ``type`` than the
     new one (typically ``design`` being shadowed by ``clone``, which is
     the real collision `scripts/curate.py` produces against bundled
-    presets like ``neutral_female`` and ``warm_female``), log at a
-    louder level so the caller cannot miss the shadowing.
+    presets like ``neutral_female`` and ``warm_female``), log a more
+    prominent warning message so the caller cannot miss the shadowing.
+    Both cases emit at the same WARNING level.
 
     Args:
         name: Voice key.
@@ -91,6 +92,11 @@ def add_voice(
 
     existing = data["voices"].get(name)
     if existing is not None:
+        if not allow_overwrite:
+            raise ValueError(
+                f"Voice {name!r} already exists. "
+                f"Pass allow_overwrite=True to overwrite it, or choose a different name."
+            )
         existing_type = existing.get("type", "unknown")
         new_type = voice_data.get("type", "unknown")
         if existing_type != new_type:
@@ -98,22 +104,21 @@ def add_voice(
                 "Voice %r is being OVERWRITTEN and its type CHANGES "
                 "(%s -> %s). This shadows the previous registration. "
                 "If %r is a bundled preset, consider registering your "
-                "custom voice under a distinct name (e.g. "
-                "%r) to avoid colliding with it.",
+                "custom voice under a distinct name with a regional suffix "
+                "(e.g. %r) to avoid colliding with it.",
                 name,
                 existing_type,
                 new_type,
                 name,
-                f"{name}_{new_type}",
+                f"{name}_es",
             )
         else:
             logger.warning(
-                "Voice %r already exists and is being overwritten (same type: %s).",
+                "Voice %r already exists and is being overwritten (same type: %s). "
+                "To keep both, register your voice under a distinct name.",
                 name,
                 existing_type,
             )
-        if not allow_overwrite:
-            raise ValueError(f"Voice {name!r} already exists and allow_overwrite=False")
 
     data["voices"][name] = voice_data
     save_voices(data, voices_file)

--- a/src/spanish_tts/config.py
+++ b/src/spanish_tts/config.py
@@ -1,10 +1,13 @@
 """Configuration management for spanish-tts."""
 
+import logging
 import os
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger("spanish-tts.config")
 
 VOICES_FILENAME = "voices.yaml"
 DEFAULT_CONFIG_DIR = Path.home() / ".spanish-tts"
@@ -58,11 +61,60 @@ def get_voice(name: str, voices_file: Path | None = None) -> dict[str, Any] | No
     return voices.get(name)
 
 
-def add_voice(name: str, voice_data: dict[str, Any], voices_file: Path | None = None):
-    """Add or update a voice in the registry."""
+def add_voice(
+    name: str,
+    voice_data: dict[str, Any],
+    voices_file: Path | None = None,
+    allow_overwrite: bool = True,
+):
+    """Add or update a voice in the registry.
+
+    When a voice with ``name`` already exists, log a warning before
+    overwriting. If the existing entry has a different ``type`` than the
+    new one (typically ``design`` being shadowed by ``clone``, which is
+    the real collision `scripts/curate.py` produces against bundled
+    presets like ``neutral_female`` and ``warm_female``), log at a
+    louder level so the caller cannot miss the shadowing.
+
+    Args:
+        name: Voice key.
+        voice_data: Voice payload (must include ``type``).
+        voices_file: Registry path; defaults to user config.
+        allow_overwrite: If False, raise ``ValueError`` instead of
+            overwriting an existing entry. Default True to preserve
+            existing callers (`scripts/curate.py` intentionally
+            replaces entries when re-exporting a clone).
+    """
     data = load_voices(voices_file)
     if "voices" not in data:
         data["voices"] = {}
+
+    existing = data["voices"].get(name)
+    if existing is not None:
+        existing_type = existing.get("type", "unknown")
+        new_type = voice_data.get("type", "unknown")
+        if existing_type != new_type:
+            logger.warning(
+                "Voice %r is being OVERWRITTEN and its type CHANGES "
+                "(%s -> %s). This shadows the previous registration. "
+                "If %r is a bundled preset, consider registering your "
+                "custom voice under a distinct name (e.g. "
+                "%r) to avoid colliding with it.",
+                name,
+                existing_type,
+                new_type,
+                name,
+                f"{name}_{new_type}",
+            )
+        else:
+            logger.warning(
+                "Voice %r already exists and is being overwritten (same type: %s).",
+                name,
+                existing_type,
+            )
+        if not allow_overwrite:
+            raise ValueError(f"Voice {name!r} already exists and allow_overwrite=False")
+
     data["voices"][name] = voice_data
     save_voices(data, voices_file)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for spanish_tts.config module."""
 
+import logging
+
 import pytest
 import yaml
 
@@ -109,8 +111,6 @@ class TestAddVoice:
 
     def test_overwrite_same_type_emits_warning(self, tmp_voices_file, caplog):
         """Overwriting a voice with the same type emits a WARNING."""
-        import logging
-
         with caplog.at_level(logging.WARNING, logger="spanish-tts.config"):
             add_voice(
                 "test_clone",
@@ -122,11 +122,13 @@ class TestAddVoice:
         assert rec.levelno == logging.WARNING
         assert "test_clone" in rec.message
         assert "overwritten" in rec.message.lower()
+        assert "CHANGES" not in rec.message  # must not route through the type-change branch
+        # Verify the overwrite actually persisted
+        updated = get_voice("test_clone", tmp_voices_file)
+        assert updated["ref_audio"] == "/tmp/new.wav"
 
     def test_overwrite_type_change_emits_loud_warning(self, tmp_voices_file, caplog):
         """Overwriting a voice with a different type emits a WARNING flagging the type change."""
-        import logging
-
         with caplog.at_level(logging.WARNING, logger="spanish-tts.config"):
             add_voice(
                 "test_design",
@@ -161,6 +163,22 @@ class TestAddVoice:
         voice = get_voice("brand_new", tmp_voices_file)
         assert voice is not None
         assert voice["instruct"] == "novel"
+
+    def test_allow_overwrite_false_type_change_also_raises(self, tmp_voices_file):
+        """allow_overwrite=False raises ValueError even when types differ."""
+        with pytest.raises(ValueError, match="test_design"):
+            add_voice(
+                "test_design",
+                {"type": "clone", "ref_audio": "/tmp/new.wav"},
+                tmp_voices_file,
+                allow_overwrite=False,
+            )
+
+    def test_add_new_voice_emits_no_warning(self, tmp_voices_file, caplog):
+        """Adding a brand-new voice emits no warnings."""
+        with caplog.at_level(logging.WARNING, logger="spanish-tts.config"):
+            add_voice("brand_new_2", {"type": "design", "instruct": "x"}, tmp_voices_file)
+        assert len(caplog.records) == 0
 
 
 class TestGetDefaults:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,6 +107,61 @@ class TestAddVoice:
         voice = get_voice("test_clone", tmp_voices_file)
         assert voice["type"] == "design"
 
+    def test_overwrite_same_type_emits_warning(self, tmp_voices_file, caplog):
+        """Overwriting a voice with the same type emits a WARNING."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="spanish-tts.config"):
+            add_voice(
+                "test_clone",
+                {"type": "clone", "ref_audio": "/tmp/new.wav"},
+                tmp_voices_file,
+            )
+        assert len(caplog.records) == 1
+        rec = caplog.records[0]
+        assert rec.levelno == logging.WARNING
+        assert "test_clone" in rec.message
+        assert "overwritten" in rec.message.lower()
+
+    def test_overwrite_type_change_emits_loud_warning(self, tmp_voices_file, caplog):
+        """Overwriting a voice with a different type emits a WARNING flagging the type change."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="spanish-tts.config"):
+            add_voice(
+                "test_design",
+                {"type": "clone", "ref_audio": "/tmp/new.wav"},
+                tmp_voices_file,
+            )
+        assert len(caplog.records) == 1
+        rec = caplog.records[0]
+        assert rec.levelno == logging.WARNING
+        assert "test_design" in rec.message
+        assert "design" in rec.message
+        assert "clone" in rec.message
+
+    def test_allow_overwrite_false_raises(self, tmp_voices_file):
+        """allow_overwrite=False raises ValueError when voice already exists."""
+        with pytest.raises(ValueError, match="test_clone"):
+            add_voice(
+                "test_clone",
+                {"type": "clone", "ref_audio": "/tmp/new.wav"},
+                tmp_voices_file,
+                allow_overwrite=False,
+            )
+
+    def test_allow_overwrite_false_new_voice_ok(self, tmp_voices_file):
+        """allow_overwrite=False does NOT raise when adding a brand-new voice."""
+        add_voice(
+            "brand_new",
+            {"type": "design", "instruct": "novel"},
+            tmp_voices_file,
+            allow_overwrite=False,
+        )
+        voice = get_voice("brand_new", tmp_voices_file)
+        assert voice is not None
+        assert voice["instruct"] == "novel"
+
 
 class TestGetDefaults:
     def test_returns_defaults(self, tmp_voices_file):


### PR DESCRIPTION
## WHY

M5 FROM UMBRELLA #2. `add_voice()` IN `config.py` HAD NO GUARD
AGAINST SILENT PRESET SHADOWING. `scripts/curate.py export` REGISTERS
CLONES UNDER WHATEVER `--voice` NAME THE USER PASSES. IF THEY PASS
`warm_female` OR `neutral_female`, THE BUNDLED PRESET (`type=design`)
GETS SILENTLY REPLACED BY THE CLONE (`type=clone`). README EXAMPLE USES
`warm_female` -- SO THIS COLLISION IS LATENT, NOT HYPOTHETICAL.

FIX CHOSEN: WARN ON OVERWRITE, LOUDER ON TYPE CHANGE. CHOSE THIS OVER
RENAMING PRESETS BECAUSE RENAMING BREAKS EXISTING USERS (README EXAMPLES,
USER REGISTRIES). THE COLLISION ONLY FIRES ON EXPLICIT USER ACTION.

## WHAT

**Commit 1 — feat(config): M5 WARN ON add_voice OVERWRITE, LOUD ON TYPE CHANGE**
- Add module logger `spanish-tts.config`
- `add_voice()` gets `allow_overwrite: bool = True` kwarg
- On overwrite same type: `logger.warning` with voice name
- On overwrite type change: louder `logger.warning` with old+new type and suggested suffix name
- `allow_overwrite=False`: raises `ValueError` instead of overwriting
- 4 new tests in `tests/test_config.py` (caplog-based): same-type warning, type-change warning, ValueError, new-voice no-error
- 93 → 97 tests passing

**Commit 2 — docs(config): M5 README COLLISION SECTION + voices.yaml HEADER WARNING**
- README: new "Name collision warning" subsection under "Adding Your Own Voices"
- `presets/voices.yaml`: multi-line header comment listing preset names + suffix recommendation

## TEST

```
97 passed in 2.82s
pre-commit run --all-files: all hooks passed
```

## RISK / ROLLBACK

RISK: MINIMAL. EXISTING CALLERS UNAFFECTED (allow_overwrite=True IS THE
DEFAULT). ONLY NEW BEHAVIOUR: LOG WARNINGS ON OVERWRITE. NO API BREAK.

ROLLBACK: `git revert <sha>` ON MAIN. CLOSES CHECKBOX M5 IN #2.