### PR TITLE
docs(readme): REL-1 WON'T-FIX PYPI -- ADD INSTALL FROM SOURCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ cd ~/Code/qwen3-tts-spanish-voices  # or wherever you cloned it
 pip install -e ".[mlx]"
 ```
 
+### Install from source (git)
+
+To install the latest release directly from GitHub without cloning:
+
+```bash
+pip install git+https://github.com/alblez/qwen3-tts-spanish-voices.git@v0.2.0
+```
+
+Or pin to main for the bleeding edge:
+
+```bash
+pip install git+https://github.com/alblez/qwen3-tts-spanish-voices.git@main
+```
+
+> This package is not published on PyPI. The MLX dependency is Apple Silicon-specific
+> and PyPI audience for this scope is negligible; direct git install covers all users.
+
 ### Speed Control (Optional)
 
 For advanced speed control with pitch preservation via librosa, install the `[speed]` extra:


### PR DESCRIPTION
## WHY

REL-1 FROM UMBRELLA #2. PyPI PUBLISH WAS OPEN AS A TODO.

WON'T-FIX -- DOCS ONLY.

REASONING: THIS PACKAGE IS MLX-ONLY, APPLE SILICON-SPECIFIC. NEAR-ZERO
PyPI AUDIENCE FOR A HOBBY-SCALE TOOL WITH NO PyPI BADGES, NO CI RELEASE
WORKFLOW, NO .pypirc, AND NO CONTRIBUTOR DEMAND SIGNAL. AN OIDC PIPELINE
LOCKS IN ONGOING MAINTENANCE COST WITH NO RETURN. THE CORRECT RESPONSE IS
TO DOCUMENT HOW TO INSTALL DIRECTLY FROM GIT, NOT TO PUBLISH TO PyPI.

v0.2.0 TAG EXISTS AT cebf301. STAYS ON GITHUB ONLY.

SEE UMBRELLA #2 FOR FULL CONTEXT.

## WHAT

**Single commit — docs(readme): REL-1 INSTALL FROM SOURCE + WON'T-FIX PYPI NOTE**
- New "Install from source (git)" subsection under Installation
- `pip install git+https://github.com/alblez/qwen3-tts-spanish-voices.git@v0.2.0` (stable)
- `pip install git+https://github.com/alblez/qwen3-tts-spanish-voices.git@main` (bleeding edge)
- Inline note explaining PyPI is intentionally skipped

## TEST

Docs-only. Pre-commit clean. 99 tests still pass (no code change).

## RISK / ROLLBACK

Zero. Docs only. Rollback: `git revert` on main.

CLOSES CHECKBOX REL-1 IN #2 AS WON'T-FIX (EXPLICIT, NOT SILENT).