### PR TITLE
docs(license): U3-1 ADD LICENSE FILE + PEP 639 MIGRATION

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Alberto González Rouillé
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "0.2.0"
 description = "Curated Spanish TTS voices using Qwen3-TTS voice cloning and design"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Alberto González Rouillé" }]
 
 dependencies = [


### PR DESCRIPTION
## WHY

REPO HAD NO LICENSE FILE. WHEELS BUILT WITHOUT ONE VIOLATE MIT DISTRIBUTION TERMS — RECIPIENTS GET NO GRANT. pyproject.toml USED LEGACY \`license = { text = "MIT" }\` INLINE FORM, DEPRECATED IN PEP 639 AND IGNORED BY setuptools<77.

## WHAT

- **commit 1**: ADD \`LICENSE\` (MIT, full text, copyright 2025-2026 ALBERTO GONZALEZ ROUILLE). MIGRATE pyproject.toml \`license = "MIT"\` + \`license-files = ["LICENSE"]\`. BUMP \`setuptools>=77\` IN \`build-system.requires\`.

## TEST

DOCS-ONLY (+ build-system metadata). PRE-COMMIT CLEAN. NO RUNTIME CODE CHANGED. VERIFY: \`python -m build && unzip -l dist/*.whl | grep LICENSE\` AFTER WHEEL BUILD.

## RISK / ROLLBACK

LOW. \`setuptools>=77\` ALREADY THE DE-FACTO MINIMUM FOR PEP 639 SUPPORT. IF BUILD BREAKS ON OLDER SETUPTOOLS: \`git revert\` + BUMP EXPLICITLY.

CLOSES CHECKBOX U3-1 IN #15.