### PR TITLE
docs(mcp): U3-5 ADD CONTRACT.md — STABLE MCP JSON SHAPES

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,0 +1,136 @@
+# MCP Contract
+
+This document defines the stable JSON shapes returned by the `spanish-tts` MCP server.
+**Shape changes are breaking — they bump the SemVer major version.**
+
+## Tools
+
+### `say`
+
+Synthesise speech from text.
+
+**Input schema**
+
+```json
+{
+  "text":   {"type": "string",  "required": true},
+  "voice":  {"type": "string",  "required": false, "default": null},
+  "speed":  {"type": "number",  "required": false, "default": null},
+  "stream": {"type": "boolean", "required": false, "default": false},
+  "output": {"type": "string",  "required": false, "default": null}
+}
+```
+
+**Success response**
+
+```json
+{"path": "<absolute-path-to-wav>", "duration_seconds": <float>}
+```
+
+> Note: `duration_seconds` is returned in the engine layer (see U3-19).
+> Until U3-19 lands the field may be absent; callers should treat it as
+> optional.
+
+**Error response**
+
+```json
+{"error": "<human-readable message>"}
+```
+
+Known error messages (stable strings):
+
+| Condition | `error` value |
+|-----------|--------------|
+| Text is empty / whitespace-only | `"text is empty"` |
+| Text contains NUL byte | `"text contains NUL byte"` |
+| Text exceeds 10 000 characters | `"text too long (N chars, max 10000)"` |
+| Voice not found in registry | `"voice '<name>' not found"` |
+| Output path outside safe root | `"output path not allowed"` |
+| Generation engine failure | `"generation failed: <reason>"` |
+
+---
+
+### `list_all_voices`
+
+Return all registered voices.
+
+**Input schema** — no required parameters.
+
+**Success response**
+
+```json
+{
+  "voices": {
+    "<voice-name>": {
+      "type":        "clone" | "design",
+      "gender":      "<string>",
+      "language":    "<string>",
+      "accent":      "<string>",
+      "description": "<string>"
+    }
+  }
+}
+```
+
+`accent` and `description` are optional; callers must handle their absence.
+
+**Error response**
+
+```json
+{"error": "<human-readable message>"}
+```
+
+---
+
+### `demo`
+
+Run `say` for every voice and return per-voice results.
+
+**Input schema**
+
+```json
+{
+  "text":       {"type": "string",  "required": false, "default": null},
+  "speed":      {"type": "number",  "required": false, "default": null},
+  "output_dir": {"type": "string",  "required": false, "default": null}
+}
+```
+
+**Success response**
+
+```json
+{
+  "results": [
+    {"voice": "<name>", "path": "<absolute-path-to-wav>", "status": "ok"},
+    {"voice": "<name>", "error": "<reason>", "status": "failed"}
+  ]
+}
+```
+
+Partial failure is normal: if one voice fails the others still run.
+`status` is always present; `path` is present on `"ok"` entries,
+`error` is present on `"failed"` entries.
+
+**Error response** (whole-tool failure, not per-voice)
+
+```json
+{"error": "<human-readable message>"}
+```
+
+---
+
+## Backward-compatibility policy
+
+1. Adding a new **optional** field to a success response is **non-breaking**.
+2. Adding a new tool is **non-breaking**.
+3. Removing a field, renaming a field, or changing a field type is **breaking** → major version bump.
+4. New `error` string values are **non-breaking**; callers must not switch-on them exhaustively.
+5. Input schema changes that drop a previously-required field are **non-breaking**.
+   Input schema changes that add a new required field are **breaking**.
+
+---
+
+## Version
+
+Contract version: **0.2.x** (aligned with package version).
+Last updated: 2026-04-26.


### PR DESCRIPTION
## WHY

MCP SERVER HAD NO DOCUMENTED CONTRACT. CALLERS HAD TO READ SOURCE TO KNOW RESPONSE SHAPES. SHAPE DRIFT ACROSS VERSIONS WOULD GO UNDETECTED.

## WHAT

- **commit 1**: ADD \`CONTRACT.md\` AT REPO ROOT. DEFINES JSON INPUT/OUTPUT SCHEMAS FOR ALL THREE TOOLS (\`say\`, \`list_all_voices\`, \`demo\`). DOCUMENTS STABLE ERROR STRINGS. DOCUMENTS BACKWARD-COMPAT POLICY (BREAKING VS NON-BREAKING, SEMVER RULES).

## TEST

DOCS-ONLY. PRE-COMMIT CLEAN. PART 2 (tests/test_mcp_protocol.py ASSERTING RUNTIME SHAPES) LANDS IN WAVE 3 AS U3-5 PART 2.

## RISK / ROLLBACK

ZERO. NEW FILE ONLY. NO CODE CHANGED.

CLOSES CHECKBOX U3-5 (PART 1) IN #15.