### PR TITLE
docs(security): U3-11 ADD SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| main (latest) | Yes |
+| 0.2.x | Yes |
+| < 0.2 | No |
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting:
+<https://github.com/alblez/qwen3-tts-spanish-voices/security/advisories/new>
+
+Please include:
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce or a proof-of-concept.
+- Affected versions.
+
+**Response time:** acknowledgement within 72 hours; coordinated fix within
+30 days where feasible. We will credit reporters unless they prefer anonymity.
+
+Do **not** open a public issue for security vulnerabilities.
+
+## Scope
+
+This project runs as a local CLI and MCP server on the user's own machine.
+The primary attack surface is the MCP `say` tool's `output=` parameter
+(path-traversal risk). Report anything that allows writing or reading files
+outside the user's home directory, or that allows code execution beyond what
+the installed package already permits.


### PR DESCRIPTION
## WHY

REPO HAD NO SECURITY POLICY. GITHUB SHOWED \"NO SECURITY POLICY\" WARNING. USERS/RESEARCHERS HAD NO CHANNEL TO REPORT VULNERABILITIES WITHOUT OPENING A PUBLIC ISSUE.

## WHAT

- **commit 1**: ADD \`SECURITY.md\`. SUPPORTED VERSIONS TABLE (main + 0.2.x SUPPORTED; <0.2 NOT). PRIVATE ADVISORY LINK. 72H ACK / 30D FIX SLA. SCOPE NOTE IDENTIFYING MCP \`output=\` PATH-TRAVERSAL AS PRIMARY ATTACK SURFACE.

## TEST

DOCS-ONLY. PRE-COMMIT CLEAN.

## RISK / ROLLBACK

ZERO. NEW FILE ONLY.

CLOSES CHECKBOX U3-11 IN #15.