### PR TITLE
fix(engine): U3-4 _model_cache CONCURRENCY LOCK + GENERATION SERIALIZER

### DIFF
--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+import threading
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
@@ -20,7 +21,22 @@ MODELS = {
     "design": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit",
 }
 
-_model_cache = {}
+# Thread-safety: _model_cache is shared across threads.
+# _cache_lock guards the cache dict — prevents duplicate loads when two threads
+# call _get_model simultaneously for the same model_id.
+# _generate_lock serializes the entire generation pipeline (model.generate →
+# _collect_audio → _apply_speed → sf.write).  The MLX/MPS execution environment
+# is not thread-safe; and stdio-MCP is pragmatically single-request-at-a-time,
+# so this lock imposes no real-world throughput cost.
+_model_cache: dict = {}
+_cache_lock = threading.Lock()
+_generate_lock = threading.Lock()
+
+
+def _clear_cache() -> None:
+    """Evict all cached models.  Used in tests to reset between runs."""
+    with _cache_lock:
+        _model_cache.clear()
 
 
 def _apply_speed(audio: np.ndarray, speed: float, sample_rate: int) -> np.ndarray:
@@ -92,13 +108,19 @@ def _apply_speed(audio: np.ndarray, speed: float, sample_rate: int) -> np.ndarra
 
 
 def _get_model(model_id: str):
-    """Load MLX model with caching."""
-    if model_id not in _model_cache:
-        from mlx_audio.tts import load_model
+    """Load MLX model with thread-safe caching.
 
-        print(f"Loading model: {model_id}", file=sys.stderr)
-        _model_cache[model_id] = load_model(model_id)
-    return _model_cache[model_id]
+    Uses a module-level lock to ensure at most one thread loads a given
+    model_id; subsequent callers receive the cached instance immediately
+    without touching the MLX runtime.
+    """
+    with _cache_lock:
+        if model_id not in _model_cache:
+            from mlx_audio.tts import load_model
+
+            print(f"Loading model: {model_id}", file=sys.stderr)
+            _model_cache[model_id] = load_model(model_id)
+        return _model_cache[model_id]
 
 
 def _resolve_output(output: str | None, prefix: str, output_dir: str | None = None) -> str:
@@ -174,29 +196,32 @@ def generate_clone(
     Returns:
         Path to generated .wav file.
     """
-    model = _get_model(model_id or MODELS["clone"])
-
     ref_path = Path(ref_audio).expanduser()
     if not ref_path.exists():
         raise FileNotFoundError(f"Reference audio not found: {ref_path}")
 
-    print(f"Cloning voice from: {ref_path}" + (" [streaming]" if stream else ""), file=sys.stderr)
-    results = model.generate(
-        text=text,
-        lang_code="auto",
-        ref_audio=str(ref_path),
-        ref_text=ref_text,
-        speed=speed,  # upstream no-op; real stretch is post-process
-        stream=stream,
-        streaming_interval=streaming_interval,
-    )
+    with _generate_lock:
+        model = _get_model(model_id or MODELS["clone"])
+        print(
+            f"Cloning voice from: {ref_path}" + (" [streaming]" if stream else ""),
+            file=sys.stderr,
+        )
+        results = model.generate(
+            text=text,
+            lang_code="auto",
+            ref_audio=str(ref_path),
+            ref_text=ref_text,
+            speed=speed,  # upstream no-op; real stretch is post-process
+            stream=stream,
+            streaming_interval=streaming_interval,
+        )
 
-    output_path = _resolve_output(output, "clone", output_dir)
-    audio_np = _collect_audio(results, stream=stream, on_chunk=on_chunk)
+        output_path = _resolve_output(output, "clone", output_dir)
+        audio_np = _collect_audio(results, stream=stream, on_chunk=on_chunk)
 
-    sample_rate = model.sample_rate
-    audio_np = _apply_speed(audio_np, speed, sample_rate)
-    sf.write(output_path, audio_np, sample_rate)
+        sample_rate = model.sample_rate
+        audio_np = _apply_speed(audio_np, speed, sample_rate)
+        sf.write(output_path, audio_np, sample_rate)
 
     duration = len(audio_np) / sample_rate
     print(f"Saved: {output_path} ({duration:.1f}s)", file=sys.stderr)
@@ -232,8 +257,6 @@ def generate_design(
     Returns:
         Path to generated .wav file.
     """
-    model = _get_model(model_id or MODELS["design"])
-
     lang_map = {
         "Spanish": "spanish",
         "English": "english",
@@ -248,26 +271,28 @@ def generate_design(
     }
     lang_code = lang_map.get(language, "spanish")
 
-    print(
-        f"Designing voice: '{instruct[:60]}...' (lang={lang_code})"
-        + (" [streaming]" if stream else ""),
-        file=sys.stderr,
-    )
-    results = model.generate(
-        text=text,
-        lang_code=lang_code,
-        instruct=instruct,
-        speed=speed,  # upstream no-op; real stretch is post-process
-        stream=stream,
-        streaming_interval=streaming_interval,
-    )
+    with _generate_lock:
+        model = _get_model(model_id or MODELS["design"])
+        print(
+            f"Designing voice: '{instruct[:60]}...' (lang={lang_code})"
+            + (" [streaming]" if stream else ""),
+            file=sys.stderr,
+        )
+        results = model.generate(
+            text=text,
+            lang_code=lang_code,
+            instruct=instruct,
+            speed=speed,  # upstream no-op; real stretch is post-process
+            stream=stream,
+            streaming_interval=streaming_interval,
+        )
 
-    output_path = _resolve_output(output, "design", output_dir)
-    audio_np = _collect_audio(results, stream=stream, on_chunk=on_chunk)
+        output_path = _resolve_output(output, "design", output_dir)
+        audio_np = _collect_audio(results, stream=stream, on_chunk=on_chunk)
 
-    sample_rate = model.sample_rate
-    audio_np = _apply_speed(audio_np, speed, sample_rate)
-    sf.write(output_path, audio_np, sample_rate)
+        sample_rate = model.sample_rate
+        audio_np = _apply_speed(audio_np, speed, sample_rate)
+        sf.write(output_path, audio_np, sample_rate)
 
     duration = len(audio_np) / sample_rate
     print(f"Saved: {output_path} ({duration:.1f}s)", file=sys.stderr)

--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -221,6 +221,9 @@ def generate_clone(
 
         sample_rate = model.sample_rate
         audio_np = _apply_speed(audio_np, speed, sample_rate)
+        # NOTE: _apply_speed (librosa time_stretch) is CPU-bound and may take
+        # several seconds at non-trivial speeds.  Move outside _generate_lock
+        # if the transport ever moves beyond single-request stdio-MCP.
         sf.write(output_path, audio_np, sample_rate)
 
     duration = len(audio_np) / sample_rate
@@ -292,6 +295,9 @@ def generate_design(
 
         sample_rate = model.sample_rate
         audio_np = _apply_speed(audio_np, speed, sample_rate)
+        # NOTE: _apply_speed (librosa time_stretch) is CPU-bound and may take
+        # several seconds at non-trivial speeds.  Move outside _generate_lock
+        # if the transport ever moves beyond single-request stdio-MCP.
         sf.write(output_path, audio_np, sample_rate)
 
     duration = len(audio_np) / sample_rate

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -114,20 +114,42 @@ class TestGenerateValidation:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(autouse=True)
-def reset_engine_cache():
-    """Reset the engine cache before and after each test in this module."""
-    _clear_cache()
-    yield
-    _clear_cache()
+def _install_fake_load_model(monkeypatch, fake_load_model):
+    """Patch mlx_audio.tts.load_model with *fake_load_model* in sys.modules.
+
+    Works whether mlx_audio is installed (Apple Silicon) or absent (CI).
+    Returns the patched eng module for convenience.
+    """
+    import sys
+    import types
+
+    import spanish_tts.engine as eng
+
+    if "mlx_audio.tts" in sys.modules:
+        monkeypatch.setattr(sys.modules["mlx_audio.tts"], "load_model", fake_load_model)
+    else:
+        fake_mlx = types.ModuleType("mlx_audio")
+        fake_tts = types.ModuleType("mlx_audio.tts")
+        fake_tts.load_model = fake_load_model
+        fake_mlx.tts = fake_tts
+        monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx)
+        monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
+    return eng
 
 
 class TestCacheLock:
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        """Isolate each test by clearing the cache before and after."""
+        _clear_cache()
+        yield
+        _clear_cache()
+
     def test_get_model_called_once_under_concurrency(self, monkeypatch):
         """Concurrent _get_model calls for the same model_id load the model
         exactly once, even under a ThreadPoolExecutor.
         """
-        import spanish_tts.engine as eng
+        import time
 
         load_count = {"n": 0}
 
@@ -136,29 +158,11 @@ class TestCacheLock:
 
         def fake_load_model(model_id):
             load_count["n"] += 1
-            # Simulate some work so threads have time to race.
-            import time
-
+            # sleep releases the GIL, giving other threads a chance to race.
             time.sleep(0.02)
             return FakeModel()
 
-        monkeypatch.setattr(eng, "_model_cache", {})
-        # Patch at the source where _get_model imports it.
-        import sys
-
-        if "mlx_audio.tts" in sys.modules:
-            monkeypatch.setattr(sys.modules["mlx_audio.tts"], "load_model", fake_load_model)
-        else:
-            # mlx_audio not installed (CI) — patch via importlib side-channel.
-            import types
-
-            fake_mlx = types.ModuleType("mlx_audio")
-            fake_tts = types.ModuleType("mlx_audio.tts")
-            fake_tts.load_model = fake_load_model
-            fake_mlx.tts = fake_tts
-            monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx)
-            monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
-
+        eng = _install_fake_load_model(monkeypatch, fake_load_model)
         model_id = MODELS["design"]
         results = []
 
@@ -175,10 +179,31 @@ class TestCacheLock:
         # All threads got the same cached object.
         assert all(r is results[0] for r in results)
 
-    def test_clear_cache_evicts_all(self, monkeypatch):
+    def test_get_model_returns_cached_on_second_call(self, monkeypatch):
+        """Sequential second call returns cached object; load_model not called again."""
+
+        load_count = {"n": 0}
+
+        class FakeModel:
+            sample_rate = 24000
+
+        def fake_load_model(model_id):
+            load_count["n"] += 1
+            return FakeModel()
+
+        eng = _install_fake_load_model(monkeypatch, fake_load_model)
+        model_id = MODELS["design"]
+
+        first = eng._get_model(model_id)
+        second = eng._get_model(model_id)
+        assert load_count["n"] == 1
+        assert first is second
+
+    def test_clear_cache_evicts_all(self):
         """_clear_cache() empties the module-level _model_cache dict."""
         import spanish_tts.engine as eng
 
+        # Mutate the real dict in place (no setattr — keeps _cache_lock consistent).
         with _cache_lock:
             eng._model_cache["fake_id"] = object()
         assert "fake_id" in eng._model_cache
@@ -187,31 +212,36 @@ class TestCacheLock:
 
 
 class TestGenerateLock:
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        """Isolate each test."""
+        _clear_cache()
+        yield
+        _clear_cache()
+
     def test_generate_lock_is_threading_lock(self):
         """_generate_lock must be a real threading.Lock (not a no-op)."""
         assert isinstance(_generate_lock, type(threading.Lock()))
 
-    def test_generate_serialized_under_concurrency(self, monkeypatch, tmp_path):
-        """Concurrent generate_design calls must not overlap — _generate_lock
-        serialises the critical section.  We detect overlap by recording
-        entry/exit timestamps and asserting no two intervals overlap.
-        """
+    def _run_serialization_test(self, monkeypatch, tmp_path, generate_fn, model_key):
+        """Shared helper: assert concurrent calls do not overlap in execution."""
         import time
 
         import spanish_tts.engine as eng
 
         intervals = []
-        lock = threading.Lock()
+        interval_lock = threading.Lock()
 
         class FakeModel:
             sample_rate = 24000
 
             def generate(self, **kwargs):
-                # Tiny sleep simulates generation work.
+                # Record timestamps inside the _generate_lock critical section.
                 start = time.monotonic()
+                # sleep releases GIL so other threads can queue behind the lock.
                 time.sleep(0.05)
                 end = time.monotonic()
-                with lock:
+                with interval_lock:
                     intervals.append((start, end))
 
                 class R:
@@ -219,31 +249,60 @@ class TestGenerateLock:
 
                 yield R()
 
-        monkeypatch.setattr(eng, "_model_cache", {MODELS["design"]: FakeModel()})
+        monkeypatch.setattr(eng, "_model_cache", {MODELS[model_key]: FakeModel()})
 
         errors = []
 
-        def run_generate(i):
+        def run(i):
             out = str(tmp_path / f"out_{i}.wav")
             try:
-                eng.generate_design(
-                    text="hola", instruct="calm voice", output=out, output_dir=str(tmp_path)
-                )
+                generate_fn(eng, out, tmp_path)
             except Exception as e:
                 errors.append(e)
 
         with ThreadPoolExecutor(max_workers=3) as pool:
-            futures = [pool.submit(run_generate, i) for i in range(3)]
+            futures = [pool.submit(run, i) for i in range(3)]
             for f in futures:
                 f.result()
 
-        assert not errors, f"generate_design raised: {errors}"
+        assert not errors, f"generate_fn raised: {errors}"
         # Verify no two intervals overlap (serialized execution).
+        # 1ms tolerance accounts for monotonic clock resolution on Linux (~1ms).
         sorted_ivs = sorted(intervals)
         for i in range(1, len(sorted_ivs)):
             prev_end = sorted_ivs[i - 1][1]
             cur_start = sorted_ivs[i][0]
             assert cur_start >= prev_end - 1e-3, (
-                f"Overlap detected: interval {i - 1} ends {prev_end:.4f}, "
-                f"interval {i} starts {cur_start:.4f}"
+                f"Overlap detected at position {i}: interval {i - 1} ends "
+                f"{prev_end:.4f}s, interval {i} starts {cur_start:.4f}s"
             )
+
+    def test_generate_design_serialized_under_concurrency(self, monkeypatch, tmp_path):
+        """Concurrent generate_design calls must not overlap."""
+
+        def fn(eng, out, tmp_path):
+            eng.generate_design(
+                text="hola", instruct="calm voice", output=out, output_dir=str(tmp_path)
+            )
+
+        self._run_serialization_test(monkeypatch, tmp_path, fn, "design")
+
+    def test_generate_clone_serialized_under_concurrency(self, monkeypatch, tmp_path):
+        """Concurrent generate_clone calls must not overlap."""
+        import numpy as np
+        import soundfile as sf
+
+        # Create a minimal ref audio file for generate_clone.
+        ref = str(tmp_path / "ref.wav")
+        sf.write(ref, np.zeros(4096, dtype=np.float32), 24000)
+
+        def fn(eng, out, tmp_path):
+            eng.generate_clone(
+                text="hola",
+                ref_audio=ref,
+                ref_text="hola",
+                output=out,
+                output_dir=str(tmp_path),
+            )
+
+        self._run_serialization_test(monkeypatch, tmp_path, fn, "clone")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,11 +1,16 @@
 """Tests for spanish_tts.engine module (no model loading)."""
 
 import inspect
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
 from spanish_tts.engine import (
     MODELS,
+    _cache_lock,
+    _clear_cache,
+    _generate_lock,
     _resolve_output,
     generate,
     generate_clone,
@@ -102,3 +107,143 @@ class TestGenerateValidation:
         config = {"type": "unknown"}
         with pytest.raises(ValueError, match="Unknown voice type"):
             generate("test", config)
+
+
+# ---------------------------------------------------------------------------
+# U3-4: _model_cache concurrency + serialization lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_engine_cache():
+    """Reset the engine cache before and after each test in this module."""
+    _clear_cache()
+    yield
+    _clear_cache()
+
+
+class TestCacheLock:
+    def test_get_model_called_once_under_concurrency(self, monkeypatch):
+        """Concurrent _get_model calls for the same model_id load the model
+        exactly once, even under a ThreadPoolExecutor.
+        """
+        import spanish_tts.engine as eng
+
+        load_count = {"n": 0}
+
+        class FakeModel:
+            sample_rate = 24000
+
+        def fake_load_model(model_id):
+            load_count["n"] += 1
+            # Simulate some work so threads have time to race.
+            import time
+
+            time.sleep(0.02)
+            return FakeModel()
+
+        monkeypatch.setattr(eng, "_model_cache", {})
+        # Patch at the source where _get_model imports it.
+        import sys
+
+        if "mlx_audio.tts" in sys.modules:
+            monkeypatch.setattr(sys.modules["mlx_audio.tts"], "load_model", fake_load_model)
+        else:
+            # mlx_audio not installed (CI) — patch via importlib side-channel.
+            import types
+
+            fake_mlx = types.ModuleType("mlx_audio")
+            fake_tts = types.ModuleType("mlx_audio.tts")
+            fake_tts.load_model = fake_load_model
+            fake_mlx.tts = fake_tts
+            monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx)
+            monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
+
+        model_id = MODELS["design"]
+        results = []
+
+        def call_get_model():
+            results.append(eng._get_model(model_id))
+
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            futures = [pool.submit(call_get_model) for _ in range(5)]
+            for f in futures:
+                f.result()
+
+        assert load_count["n"] == 1, f"Expected 1 load, got {load_count['n']}"
+        assert len(results) == 5
+        # All threads got the same cached object.
+        assert all(r is results[0] for r in results)
+
+    def test_clear_cache_evicts_all(self, monkeypatch):
+        """_clear_cache() empties the module-level _model_cache dict."""
+        import spanish_tts.engine as eng
+
+        with _cache_lock:
+            eng._model_cache["fake_id"] = object()
+        assert "fake_id" in eng._model_cache
+        _clear_cache()
+        assert eng._model_cache == {}
+
+
+class TestGenerateLock:
+    def test_generate_lock_is_threading_lock(self):
+        """_generate_lock must be a real threading.Lock (not a no-op)."""
+        assert isinstance(_generate_lock, type(threading.Lock()))
+
+    def test_generate_serialized_under_concurrency(self, monkeypatch, tmp_path):
+        """Concurrent generate_design calls must not overlap — _generate_lock
+        serialises the critical section.  We detect overlap by recording
+        entry/exit timestamps and asserting no two intervals overlap.
+        """
+        import time
+
+        import spanish_tts.engine as eng
+
+        intervals = []
+        lock = threading.Lock()
+
+        class FakeModel:
+            sample_rate = 24000
+
+            def generate(self, **kwargs):
+                # Tiny sleep simulates generation work.
+                start = time.monotonic()
+                time.sleep(0.05)
+                end = time.monotonic()
+                with lock:
+                    intervals.append((start, end))
+
+                class R:
+                    audio = [0.0] * 100
+
+                yield R()
+
+        monkeypatch.setattr(eng, "_model_cache", {MODELS["design"]: FakeModel()})
+
+        errors = []
+
+        def run_generate(i):
+            out = str(tmp_path / f"out_{i}.wav")
+            try:
+                eng.generate_design(
+                    text="hola", instruct="calm voice", output=out, output_dir=str(tmp_path)
+                )
+            except Exception as e:
+                errors.append(e)
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(run_generate, i) for i in range(3)]
+            for f in futures:
+                f.result()
+
+        assert not errors, f"generate_design raised: {errors}"
+        # Verify no two intervals overlap (serialized execution).
+        sorted_ivs = sorted(intervals)
+        for i in range(1, len(sorted_ivs)):
+            prev_end = sorted_ivs[i - 1][1]
+            cur_start = sorted_ivs[i][0]
+            assert cur_start >= prev_end - 1e-3, (
+                f"Overlap detected: interval {i - 1} ends {prev_end:.4f}, "
+                f"interval {i} starts {cur_start:.4f}"
+            )


### PR DESCRIPTION
## WHY

\`_model_cache\` HAD NO LOCK — CONCURRENT \`_get_model\` CALLS COULD LOAD THE SAME 3GB MLX MODEL TWICE AND CORRUPT CACHE STATE. THE GENERATE PIPELINE HAD NO SERIALISATION — CONCURRENT SYNTHESIS INTO THE SAME MLX/MPS RUNTIME COULD PRODUCE INTERLEAVED AUDIO. STDIO-MCP IS SINGLE-REQUEST-AT-A-TIME IN PRACTICE, BUT CODE GAVE NO THREAD-SAFETY GUARANTEES.

## WHAT

- **commit 1**: ADD \`_cache_lock = threading.Lock()\` — wraps \`_get_model\` body; at most one thread loads a model_id.
- **commit 1**: ADD \`_generate_lock = threading.Lock()\` — serializes \`model.generate → _collect_audio → _apply_speed → sf.write\` in both \`generate_clone\` and \`generate_design\`.
- **commit 1**: ADD \`_clear_cache()\` helper — explicit cache teardown for test fixtures.
- **commit 1**: Document thread-safety contract in module-level comments.
- **commit 1**: 4 new concurrency tests (ThreadPoolExecutor load-once, interval-overlap serialization check, lock type assertion, cache eviction).

## TEST

103 tests passing (was 99). Pre-commit clean.

New test classes: \`TestCacheLock\`, \`TestGenerateLock\`.

## RISK / ROLLBACK

LOW. Locking is additive for single-threaded callers — no behavior change. \`_generate_lock\` does serialize generation on multi-threaded MCP dispatch, but stdio-MCP is single-request-at-a-time anyway. If false contention appears: revert the \`_generate_lock\` wrapping only (keep \`_cache_lock\`).

CLOSES CHECKBOX U3-4 IN #15.