### PR TITLE
build(pyproject): U3-20 CLASSIFIERS + URLS + KEYWORDS + requires_mlx MARKER

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,24 @@ requires-python = ">=3.11"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Alberto González Rouillé" }]
+keywords = ["tts", "spanish", "qwen3", "mlx", "apple-silicon", "voice-cloning", "mcp"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Multimedia :: Sound/Audio :: Speech",
+    "Topic :: Multimedia :: Sound/Audio :: Sound Synthesis",
+]
+
+[project.urls]
+Homepage = "https://github.com/alblez/qwen3-tts-spanish-voices"
+Source = "https://github.com/alblez/qwen3-tts-spanish-voices"
+Issues = "https://github.com/alblez/qwen3-tts-spanish-voices/issues"
+Changelog = "https://github.com/alblez/qwen3-tts-spanish-voices/blob/main/CHANGELOG.md"
 
 dependencies = [
     "click>=8.0",
@@ -54,6 +72,7 @@ where = ["src"]
 # require heavy extras (mlx, large model downloads, or long audio synthesis).
 markers = [
     "slow: heavy tests that need the [mlx] extra or long synthesis runs (skipped in CI and pre-push pytest)",
+    "requires_mlx: tests that need Apple Silicon + the [mlx] extra (skipped in CI ubuntu leg)",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ authors = [{ name = "Alberto González Rouillé" }]
 keywords = ["tts", "spanish", "qwen3", "mlx", "apple-silicon", "voice-cloning", "mcp"]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,6 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Sound Synthesis",
 ]
 
-[project.urls]
-Homepage = "https://github.com/alblez/qwen3-tts-spanish-voices"
-Source = "https://github.com/alblez/qwen3-tts-spanish-voices"
-Issues = "https://github.com/alblez/qwen3-tts-spanish-voices/issues"
-Changelog = "https://github.com/alblez/qwen3-tts-spanish-voices/blob/main/CHANGELOG.md"
-
 dependencies = [
     "click>=8.0",
     "pyyaml>=6.0",
@@ -59,6 +53,12 @@ dev = [
     "ruff==0.15.*",
     "pre-commit>=3",
 ]
+
+[project.urls]
+Homepage = "https://github.com/alblez/qwen3-tts-spanish-voices"
+Source = "https://github.com/alblez/qwen3-tts-spanish-voices"
+Issues = "https://github.com/alblez/qwen3-tts-spanish-voices/issues"
+Changelog = "https://github.com/alblez/qwen3-tts-spanish-voices/blob/main/CHANGELOG.md"
 
 [project.scripts]
 spanish-tts = "spanish_tts.cli:cli"


### PR DESCRIPTION
## WHY

pyproject.toml HAD NO CLASSIFIERS, NO PROJECT URLS, AND NO KEYWORDS. PACKAGE METADATA WAS INCOMPLETE. requires_mlx PYTEST MARKER WAS REFERENCED IN ARCHITECTURE.md BUT UNREGISTERED IN pyproject.

## WHAT

- **commit 1**: ADD \`[project.urls]\` (Homepage, Source, Issues, Changelog).
- **commit 1**: ADD \`classifiers\` (Dev Status 4-Beta, MIT, Python 3.11/3.12/3.13, macOS, Topic Multimedia Sound Audio).
- **commit 1**: ADD \`keywords\` (tts, spanish, qwen3, mlx, apple-silicon, voice-cloning, mcp).
- **commit 1**: ADD \`requires_mlx\` marker definition in \`[tool.pytest.ini_options]\`.

## TEST

PRE-COMMIT CLEAN. 120 TESTS PASSING. DEPENDS ON U3-1 (#16 MERGED) FOR SPDX LICENSE FORM.

## RISK / ROLLBACK

ZERO. METADATA ONLY.

CLOSES CHECKBOX U3-20 IN #15.