### PR TITLE
test(rehab): U3-6 TESTING REHAB — ERROR BRANCHES + INTEGRATION + SPEED

### DIFF
--- a/tests/test_engine_integration.py
+++ b/tests/test_engine_integration.py
@@ -1,0 +1,184 @@
+"""Engine slow/MLX integration tests (U3-6, Subagent B).
+
+Covers engine.py lines uncovered by the fast test suite:
+  - _collect_audio streaming path (stream=True with chunks)
+  - generate_clone missing ref_audio (FileNotFoundError)
+  - _get_model cache hit via direct cache injection
+  - generate_design language mapping for all 10 lang_map entries
+
+All tests carry @pytest.mark.slow and @pytest.mark.requires_mlx.
+No real MLX model is loaded — all heavy callouts are monkeypatched.
+"""
+
+import numpy as np
+import pytest
+
+import spanish_tts.engine as eng
+from spanish_tts.engine import (
+    MODELS,
+    _cache_lock,
+    _clear_cache,
+    _collect_audio,
+    _get_model,
+    _model_cache,
+    generate_clone,
+    generate_design,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: minimal stand-in for mlx_audio GenerationResult
+# ---------------------------------------------------------------------------
+
+
+class _R:
+    """Minimal stand-in for mlx_audio GenerationResult."""
+
+    def __init__(self, n_samples: int):
+        self.audio = [0.0] * n_samples
+
+
+# ---------------------------------------------------------------------------
+# A. _collect_audio streaming path (lines 159-167)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.requires_mlx
+class TestCollectAudioStreaming:
+    def test_three_chunks_concatenated(self):
+        """stream=True: 3 × 1000-sample chunks → 3000-sample output."""
+        results = iter([_R(1000), _R(1000), _R(1000)])
+        out = _collect_audio(results, stream=True)
+        assert len(out) == 3000
+
+    def test_on_chunk_called_per_chunk(self):
+        """on_chunk invoked once per chunk with correct chunk_index and cumulative totals."""
+        calls = []
+
+        def cb(chunk_index, total_samples, est_duration):
+            calls.append((chunk_index, total_samples))
+
+        results = iter([_R(1000), _R(1000), _R(1000)])
+        _collect_audio(results, stream=True, on_chunk=cb)
+
+        assert len(calls) == 3
+        assert calls[0] == (0, 1000)
+        assert calls[1] == (1, 2000)
+        assert calls[2] == (2, 3000)
+
+    def test_on_chunk_none_does_not_crash(self):
+        """stream=True with on_chunk=None runs without error."""
+        results = iter([_R(500), _R(500)])
+        out = _collect_audio(results, stream=True, on_chunk=None)
+        assert len(out) == 1000
+
+    def test_empty_stream_returns_empty_float32(self):
+        """stream=True with no chunks → empty float32 array."""
+        out = _collect_audio(iter([]), stream=True)
+        assert isinstance(out, np.ndarray)
+        assert len(out) == 0
+        assert out.dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# B. generate_clone missing ref_audio (line 201)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.requires_mlx
+class TestGenerateCloneMissingRefAudio:
+    def test_nonexistent_ref_audio_raises_fnf(self):
+        """Passing a non-existent path raises FileNotFoundError before model load."""
+        with pytest.raises(FileNotFoundError, match="Reference audio not found"):
+            generate_clone(
+                text="hola",
+                ref_audio="/nonexistent/path/ref.wav",
+                ref_text="hola",
+            )
+
+    def test_error_message_includes_path(self):
+        """FileNotFoundError message includes the bad path for debuggability."""
+        bad = "/absolutely/not/there.wav"
+        with pytest.raises(FileNotFoundError) as exc_info:
+            generate_clone(text="hola", ref_audio=bad, ref_text="")
+        assert bad in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# C. _get_model cache hit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.requires_mlx
+class TestGetModelCacheHit:
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        _clear_cache()
+        yield
+        _clear_cache()
+
+    def test_same_object_on_repeated_call(self, monkeypatch):
+        """Pre-seed _model_cache; two _get_model calls return the same instance."""
+
+        class FakeModel:
+            sample_rate = 24000
+
+        fake = FakeModel()
+        model_id = MODELS["design"]
+        with _cache_lock:
+            _model_cache[model_id] = fake
+
+        assert _get_model(model_id) is fake
+        assert _get_model(model_id) is fake
+
+
+# ---------------------------------------------------------------------------
+# D. generate_design language mapping — all 10 lang_map entries
+# ---------------------------------------------------------------------------
+
+_LANG_MAP = {
+    "Spanish": "spanish",
+    "English": "english",
+    "Chinese": "chinese",
+    "French": "french",
+    "German": "german",
+    "Italian": "italian",
+    "Portuguese": "portuguese",
+    "Japanese": "japanese",
+    "Korean": "korean",
+    "Russian": "russian",
+}
+
+
+@pytest.mark.slow
+@pytest.mark.requires_mlx
+@pytest.mark.parametrize("language,expected_code", list(_LANG_MAP.items()))
+def test_generate_design_language_mapping(monkeypatch, tmp_path, language, expected_code):
+    """generate_design passes the correct lang_code to model.generate() for each language."""
+    captured = {}
+
+    class FakeModel:
+        sample_rate = 24000
+
+        def generate(self, **kwargs):
+            captured["lang_code"] = kwargs.get("lang_code")
+            yield _R(100)
+
+    # Pre-seed the cache so _get_model returns FakeModel without touching mlx_audio.
+    monkeypatch.setattr(eng, "_model_cache", {MODELS["design"]: FakeModel()})
+
+    try:
+        generate_design(
+            text="prueba",
+            instruct="a calm voice",
+            language=language,
+            output=str(tmp_path / "out.wav"),
+        )
+    finally:
+        _clear_cache()
+
+    assert captured.get("lang_code") == expected_code, (
+        f"language={language!r}: expected={expected_code!r}, got={captured.get('lang_code')!r}"
+    )

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -1,0 +1,328 @@
+"""MCP server error-branch unit tests (U3-6, Subagent A).
+
+Covers lines in mcp_server.py that were uncovered by the existing test suite:
+  - say(): empty/whitespace text, too-long text, voice not found, path OSError,
+    generate() exception, sf.info failure, stream=True on_chunk wiring
+  - list_all_voices(): clone accent field, exception fallback
+  - demo(): empty text, partial failure loop
+"""
+
+import importlib
+import logging
+import sys
+import types
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bundled_presets(tmp_path, monkeypatch):
+    """Point SPANISH_TTS_CONFIG at an empty dir so load_voices() falls back
+    to the bundled presets/voices.yaml.  Reloads modules to pick up new env.
+    """
+    monkeypatch.setenv("SPANISH_TTS_CONFIG", str(tmp_path))
+    for mod in ("spanish_tts.config", "spanish_tts.mcp_server"):
+        sys.modules.pop(mod, None)
+    import spanish_tts.mcp_server as mcp_server
+
+    importlib.reload(mcp_server)
+    yield mcp_server
+    for mod in ("spanish_tts.config", "spanish_tts.mcp_server"):
+        sys.modules.pop(mod, None)
+
+
+def _fake_sf_module(duration=2.0):
+    """Return a minimal soundfile stand-in whose info() returns a given duration."""
+
+    class _Info:
+        pass
+
+    inst = _Info()
+    inst.duration = duration
+
+    fake_sf = types.ModuleType("soundfile")
+    fake_sf.info = lambda p: inst
+    return fake_sf
+
+
+# ---------------------------------------------------------------------------
+# say() — text validation
+# ---------------------------------------------------------------------------
+
+
+class TestSayTextValidation:
+    def test_empty_string_rejected(self, bundled_presets):
+        result = bundled_presets.say(text="")
+        assert result == {"error": "text is empty"}
+
+    def test_whitespace_only_rejected(self, bundled_presets):
+        result = bundled_presets.say(text="   \t\n")
+        assert result == {"error": "text is empty"}
+
+    def test_text_too_long_rejected(self, bundled_presets):
+        result = bundled_presets.say(text="a" * 10001)
+        assert "error" in result
+        assert "too long" in result["error"]
+        assert "10001" in result["error"]
+
+    def test_text_exactly_10000_accepted(self, bundled_presets, monkeypatch, tmp_path):
+        mcp = bundled_presets
+        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(mcp, "generate", lambda **kw: str(tmp_path / "out.wav"))
+        monkeypatch.setitem(sys.modules, "soundfile", _fake_sf_module())
+        result = mcp.say(text="a" * 10000, voice="neutral_male")
+        assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# say() — voice not found
+# ---------------------------------------------------------------------------
+
+
+class TestSayVoiceNotFound:
+    def test_nonexistent_voice_returns_error(self, bundled_presets):
+        result = bundled_presets.say(text="hola", voice="__no_such_voice__")
+        assert "error" in result
+        assert "__no_such_voice__" in result["error"]
+
+    def test_error_lists_available_voices(self, bundled_presets):
+        result = bundled_presets.say(text="hola", voice="__no_such_voice__")
+        assert "Available" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# say() — path OSError (lines 99-100)
+# ---------------------------------------------------------------------------
+
+
+class TestSayPathOsError:
+    def test_oserror_from_resolve_returns_error(self, bundled_presets, tmp_path, monkeypatch):
+        from pathlib import Path
+
+        mcp = bundled_presets
+        monkeypatch.setattr(
+            mcp, "generate",
+            lambda *a, **kw: pytest.fail("generate() must not be called"),
+        )
+        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+        real_resolve = Path.resolve
+
+        def patched_resolve(self, strict=False):
+            if "trigger_oserr" in str(self):
+                raise OSError("simulated OS error during resolve")
+            return real_resolve(self, strict=strict)
+
+        monkeypatch.setattr(Path, "resolve", patched_resolve)
+        result = mcp.say(text="hola", voice="neutral_male", output="trigger_oserr/out.wav")
+        assert "error" in result
+        assert "cannot be resolved" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# say() — generate() exception (lines 137-139)
+# ---------------------------------------------------------------------------
+
+
+class TestSayGenerateException:
+    def test_generate_exception_returns_error_dict(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(mcp, "generate", lambda **kw: (_ for _ in ()).throw(RuntimeError("boom")))
+        result = mcp.say(text="hola", voice="neutral_male")
+        assert "error" in result
+        assert "Generation failed" in result["error"]
+        assert "boom" in result["error"]
+
+    def test_generate_exception_is_logged(self, bundled_presets, tmp_path, monkeypatch, caplog):
+        mcp = bundled_presets
+        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(mcp, "generate", lambda **kw: (_ for _ in ()).throw(RuntimeError("kaboom")))
+        with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):
+            mcp.say(text="hola", voice="neutral_male")
+        assert any("generate() failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# say() — sf.info() failure (line 145 → duration_seconds=None)
+# ---------------------------------------------------------------------------
+
+
+class TestSaySfInfoFailure:
+    def test_broken_wav_returns_duration_none(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(mcp, "generate", lambda **kw: str(tmp_path / "out.wav"))
+
+        bad_sf = types.ModuleType("soundfile")
+        bad_sf.info = lambda p: (_ for _ in ()).throw(Exception("not a wav"))
+        monkeypatch.setitem(sys.modules, "soundfile", bad_sf)
+
+        result = mcp.say(text="hola", voice="neutral_male")
+        assert "error" not in result
+        assert result["duration_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# say() — stream wiring (on_chunk callback)
+# ---------------------------------------------------------------------------
+
+
+class TestSayStreamWiring:
+    def test_stream_true_passes_on_chunk_to_generate(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+
+        captured = {}
+
+        def fake_generate(**kwargs):
+            captured.update(kwargs)
+            return str(tmp_path / "out.wav")
+
+        monkeypatch.setattr(mcp, "generate", fake_generate)
+        monkeypatch.setitem(sys.modules, "soundfile", _fake_sf_module(1.5))
+
+        mcp.say(text="hola", voice="neutral_male", stream=True)
+        assert captured.get("on_chunk") is not None
+        assert callable(captured["on_chunk"])
+        # Verify on_chunk doesn't raise when invoked.
+        captured["on_chunk"](0, 24000, 1.0)
+
+    def test_stream_false_passes_none_on_chunk(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        captured = {}
+        monkeypatch.setattr(mcp, "generate", lambda **kw: (captured.update(kw), str(tmp_path / "x.wav"))[1])
+        monkeypatch.setitem(sys.modules, "soundfile", _fake_sf_module())
+        mcp.say(text="hola", voice="neutral_male", stream=False)
+        assert captured["on_chunk"] is None
+
+
+# ---------------------------------------------------------------------------
+# list_all_voices() — clone voice accent + exception (lines 170, 179-181)
+# ---------------------------------------------------------------------------
+
+
+class TestListAllVoicesErrorBranches:
+    def test_clone_voice_has_accent_in_summary(self, tmp_path, monkeypatch):
+        """Clone voice accent field is included in list_all_voices output."""
+        monkeypatch.setenv("SPANISH_TTS_CONFIG", str(tmp_path))
+        for mod in ("spanish_tts.config", "spanish_tts.mcp_server"):
+            sys.modules.pop(mod, None)
+
+        voices_data = {
+            "voices": {
+                "test_clone": {
+                    "type": "clone",
+                    "gender": "male",
+                    "language": "Spanish",
+                    "ref_audio": "/tmp/ref.wav",
+                    "accent": "mexico",
+                }
+            }
+        }
+        (tmp_path / "voices.yaml").write_text(yaml.dump(voices_data), encoding="utf-8")
+
+        import spanish_tts.mcp_server as mcp_server
+        importlib.reload(mcp_server)
+
+        result = mcp_server.list_all_voices()
+        for mod in ("spanish_tts.config", "spanish_tts.mcp_server"):
+            sys.modules.pop(mod, None)
+
+        assert "voices" in result
+        assert "test_clone" in result["voices"]
+        assert result["voices"]["test_clone"]["accent"] == "mexico"
+
+    def test_list_voices_exception_returns_error_dict(self, bundled_presets, monkeypatch, caplog):
+        mcp = bundled_presets
+        monkeypatch.setattr(mcp, "list_voices", lambda **kw: (_ for _ in ()).throw(RuntimeError("broken")))
+        with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):
+            result = mcp.list_all_voices()
+        assert "error" in result
+        assert "Failed to list voices" in result["error"]
+        assert any("list_voices() failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# demo() — empty text + partial failure (lines 197, 207-224)
+# ---------------------------------------------------------------------------
+
+
+class TestDemoErrorBranches:
+    def test_empty_text_returns_error(self, bundled_presets):
+        result = bundled_presets.demo(text="")
+        assert result == {"error": "text is empty"}
+
+    def test_whitespace_text_returns_error(self, bundled_presets):
+        result = bundled_presets.demo(text="  ")
+        assert result == {"error": "text is empty"}
+
+    def test_generates_result_per_voice(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        voices = mcp.list_voices()
+        assert voices, "Need bundled voices for this test"
+
+        def fake_generate(**kw):
+            return kw["output"]
+
+        monkeypatch.setattr(mcp, "generate", fake_generate)
+        result = mcp.demo(text="hola", output_dir=str(tmp_path / "demo_out"))
+        assert "results" in result
+        assert len(result["results"]) == len(voices)
+        for entry in result["results"]:
+            assert entry["status"] == "ok"
+
+    def test_partial_failure_continues(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        voices = list(mcp.list_voices().keys())
+        assert len(voices) >= 2, "Need ≥2 voices for partial-failure test"
+        first = voices[0]
+
+        def fake_generate(**kw):
+            name = kw["output"].split("/")[-1].replace(".wav", "")
+            if name == first:
+                raise RuntimeError(f"{first} simulated failure")
+            return kw["output"]
+
+        monkeypatch.setattr(mcp, "generate", fake_generate)
+        result = mcp.demo(text="hola", output_dir=str(tmp_path / "partial"))
+        statuses = {r["voice"]: r["status"] for r in result["results"]}
+        assert statuses[first] == "failed"
+        assert any(s == "ok" for s in statuses.values())
+
+    def test_partial_failure_entry_has_error_field(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        first = list(mcp.list_voices().keys())[0]
+
+        monkeypatch.setattr(
+            mcp, "generate",
+            lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))
+            if kw["output"].endswith(f"{first}.wav")
+            else kw["output"],
+        )
+        result = mcp.demo(text="hola", output_dir=str(tmp_path / "err_field"))
+        failed = [r for r in result["results"] if r["voice"] == first]
+        assert failed
+        assert "error" in failed[0]
+
+    def test_partial_failure_logs_error(self, bundled_presets, tmp_path, monkeypatch, caplog):
+        mcp = bundled_presets
+        first = list(mcp.list_voices().keys())[0]
+
+        def boom(**kw):
+            name = kw["output"].split("/")[-1].replace(".wav", "")
+            if name == first:
+                raise RuntimeError("demo kaboom")
+            return kw["output"]
+
+        monkeypatch.setattr(mcp, "generate", boom)
+        with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):
+            mcp.demo(text="hola", output_dir=str(tmp_path / "log_demo"))
+        assert any("demo generate for" in r.message for r in caplog.records)

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -15,7 +15,6 @@ import types
 import pytest
 import yaml
 
-
 # ---------------------------------------------------------------------------
 # Fixture
 # ---------------------------------------------------------------------------
@@ -73,7 +72,9 @@ class TestSayTextValidation:
 
     def test_text_exactly_10000_accepted(self, bundled_presets, monkeypatch, tmp_path):
         mcp = bundled_presets
-        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
         monkeypatch.setattr(mcp, "generate", lambda **kw: str(tmp_path / "out.wav"))
         monkeypatch.setitem(sys.modules, "soundfile", _fake_sf_module())
         result = mcp.say(text="a" * 10000, voice="neutral_male")
@@ -107,10 +108,13 @@ class TestSayPathOsError:
 
         mcp = bundled_presets
         monkeypatch.setattr(
-            mcp, "generate",
+            mcp,
+            "generate",
             lambda *a, **kw: pytest.fail("generate() must not be called"),
         )
-        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
 
         real_resolve = Path.resolve
 
@@ -133,8 +137,12 @@ class TestSayPathOsError:
 class TestSayGenerateException:
     def test_generate_exception_returns_error_dict(self, bundled_presets, tmp_path, monkeypatch):
         mcp = bundled_presets
-        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
-        monkeypatch.setattr(mcp, "generate", lambda **kw: (_ for _ in ()).throw(RuntimeError("boom")))
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
+        monkeypatch.setattr(
+            mcp, "generate", lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
         result = mcp.say(text="hola", voice="neutral_male")
         assert "error" in result
         assert "Generation failed" in result["error"]
@@ -142,8 +150,12 @@ class TestSayGenerateException:
 
     def test_generate_exception_is_logged(self, bundled_presets, tmp_path, monkeypatch, caplog):
         mcp = bundled_presets
-        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
-        monkeypatch.setattr(mcp, "generate", lambda **kw: (_ for _ in ()).throw(RuntimeError("kaboom")))
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
+        monkeypatch.setattr(
+            mcp, "generate", lambda **kw: (_ for _ in ()).throw(RuntimeError("kaboom"))
+        )
         with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):
             mcp.say(text="hola", voice="neutral_male")
         assert any("generate() failed" in r.message for r in caplog.records)
@@ -157,7 +169,9 @@ class TestSayGenerateException:
 class TestSaySfInfoFailure:
     def test_broken_wav_returns_duration_none(self, bundled_presets, tmp_path, monkeypatch):
         mcp = bundled_presets
-        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
         monkeypatch.setattr(mcp, "generate", lambda **kw: str(tmp_path / "out.wav"))
 
         bad_sf = types.ModuleType("soundfile")
@@ -177,7 +191,9 @@ class TestSaySfInfoFailure:
 class TestSayStreamWiring:
     def test_stream_true_passes_on_chunk_to_generate(self, bundled_presets, tmp_path, monkeypatch):
         mcp = bundled_presets
-        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
 
         captured = {}
 
@@ -196,9 +212,13 @@ class TestSayStreamWiring:
 
     def test_stream_false_passes_none_on_chunk(self, bundled_presets, tmp_path, monkeypatch):
         mcp = bundled_presets
-        monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
         captured = {}
-        monkeypatch.setattr(mcp, "generate", lambda **kw: (captured.update(kw), str(tmp_path / "x.wav"))[1])
+        monkeypatch.setattr(
+            mcp, "generate", lambda **kw: (captured.update(kw), str(tmp_path / "x.wav"))[1]
+        )
         monkeypatch.setitem(sys.modules, "soundfile", _fake_sf_module())
         mcp.say(text="hola", voice="neutral_male", stream=False)
         assert captured["on_chunk"] is None
@@ -230,6 +250,7 @@ class TestListAllVoicesErrorBranches:
         (tmp_path / "voices.yaml").write_text(yaml.dump(voices_data), encoding="utf-8")
 
         import spanish_tts.mcp_server as mcp_server
+
         importlib.reload(mcp_server)
 
         result = mcp_server.list_all_voices()
@@ -242,7 +263,9 @@ class TestListAllVoicesErrorBranches:
 
     def test_list_voices_exception_returns_error_dict(self, bundled_presets, monkeypatch, caplog):
         mcp = bundled_presets
-        monkeypatch.setattr(mcp, "list_voices", lambda **kw: (_ for _ in ()).throw(RuntimeError("broken")))
+        monkeypatch.setattr(
+            mcp, "list_voices", lambda **kw: (_ for _ in ()).throw(RuntimeError("broken"))
+        )
         with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):
             result = mcp.list_all_voices()
         assert "error" in result
@@ -302,10 +325,13 @@ class TestDemoErrorBranches:
         first = list(mcp.list_voices().keys())[0]
 
         monkeypatch.setattr(
-            mcp, "generate",
-            lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))
-            if kw["output"].endswith(f"{first}.wav")
-            else kw["output"],
+            mcp,
+            "generate",
+            lambda **kw: (
+                (_ for _ in ()).throw(RuntimeError("boom"))
+                if kw["output"].endswith(f"{first}.wav")
+                else kw["output"]
+            ),
         )
         result = mcp.demo(text="hola", output_dir=str(tmp_path / "err_field"))
         failed = [r for r in result["results"] if r["voice"] == first]

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -357,3 +357,32 @@ class TestApplySpeedInputGuards:
         audio = np.zeros(2047, dtype=np.float32)
         with pytest.raises(ValueError, match="at least"):
             _apply_speed(audio, 1.5, 24000)
+
+
+# ---------------------------------------------------------------------------
+# U3-6: Speed boundary parametrized tests — NaN, inf, and edge values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_speed",
+    [
+        pytest.param(float("nan"), id="nan"),
+        pytest.param(float("inf"), id="pos_inf"),
+        pytest.param(float("-inf"), id="neg_inf"),
+        pytest.param(0.4999, id="just_below_min"),
+        pytest.param(2.0001, id="just_above_max"),
+        pytest.param(-1.0, id="negative"),
+        pytest.param(0.0, id="zero"),
+    ],
+)
+def test_apply_speed_rejects_invalid_speeds(bad_speed):
+    """_apply_speed must raise ValueError for all invalid speed values.
+
+    NaN/inf: the range check `not (0.5 <= x <= 2.0)` correctly evaluates
+    to True for NaN (all comparisons return False) and for ±inf (inf > 2.0).
+    All cases therefore raise ValueError before touching librosa.
+    """
+    audio = np.zeros(24000, dtype=np.float32)
+    with pytest.raises(ValueError):
+        _apply_speed(audio, bad_speed, 24000)


### PR DESCRIPTION
## WHY

TEST SUITE HAD 65% COVERAGE. mcp_server.py AT 57% — ENTIRE ERROR BRANCH SURFACE UNTESTED. STREAMING PATH, LANGUAGE MAP, DEMO PARTIAL FAILURE, GENERATE() EXCEPTION LOGGING ALL DARK.

## WHAT

- **commit 1**: ADD \`tests/test_mcp_errors.py\` (20 TESTS) — say() ERROR BRANCHES (EMPTY/TOO-LONG TEXT, VOICE NOT FOUND, OSError PATH, GENERATE EXCEPTION + LOG, sf.info FAIL → duration=None, STREAM WIRING), list_all_voices() CLONE ACCENT + EXCEPTION, demo() PARTIAL FAILURE LOOP.
- **commit 1**: ADD \`tests/test_engine_integration.py\` (17 TESTS) — MARKED slow+requires_mlx. _collect_audio STREAMING (3 CHUNKS, on_chunk CALLBACK, EMPTY STREAM), generate_clone MISSING ref_audio, _get_model CACHE HIT, generate_design ALL 10 LANGUAGE MAP ENTRIES.
- **commit 1**: EXTEND \`tests/test_speed.py\` (7 NEW TESTS) — PARAMETRIZED NaN/±inf/BOUNDARY REJECTION.

## TEST

164 TESTS PASSING (WAS 120). PRE-COMMIT CLEAN.
COVERAGE: mcp_server 81% (WAS 57%), TOTAL 83% (WAS 65%).
\`pytest -m "not slow"\`: 147 passing (17 slow tests deselected in CI).

## RISK / ROLLBACK

ZERO. TEST FILES ONLY. NO PRODUCTION CODE CHANGED.

CLOSES CHECKBOX U3-6 IN #15.