### PR TITLE
fix(config): WIRE _validate_voices_schema INTO PRODUCTION PATHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `[project.urls]`, `classifiers`, `keywords` added to `pyproject.toml`; `requires_mlx` marker registered (U3-20).
 
 ### Changed
+- `load_voices` now falls back to bundled presets (with a logged error) when the user's `voices.yaml` contains schema-invalid entries, in addition to the existing `YAMLError` fallback. The user's corrupt file is NOT overwritten.
 - `config.py` `save_voices()` now writes atomically via `.yaml.tmp` + `os.replace` (U3-3).
 - `config.py` `load_voices()` catches `yaml.YAMLError`, falls back to bundled presets, never overwrites corrupt user file (U3-3).
 - `config.py` validates `SPANISH_TTS_CONFIG` env var resolves under `$HOME` before `mkdir` (U3-3).
@@ -33,6 +34,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Logger names unified under `spanish_tts.*` namespace (U3-3).
 
 ### Fixed
+- Wire `_validate_voices_schema` into `load_voices`/`save_voices` so malformed voice entries can no longer pass through unchecked. Previously the validator was defined and tested but never called in production.
 - Speed boundary tests: parametrized NaN/±inf/edge-value rejection by `_apply_speed` (U3-6).
 
 ---

--- a/src/spanish_tts/config.py
+++ b/src/spanish_tts/config.py
@@ -102,15 +102,20 @@ def _validate_voices_schema(data: dict[str, Any], source: Path) -> None:
 def load_voices(voices_file: Path | None = None) -> dict[str, Any]:
     """Load voice registry from YAML.
 
-    Falls back to the bundled presets if the user voices file is corrupt
-    (logs the error; does **not** overwrite the corrupt file — the user
-    must recover it manually or delete it to reset to presets).
+    Falls back to the bundled presets if the user voices file is corrupt or
+    schema-invalid (logs the error; does **not** overwrite the corrupt file —
+    the user must recover it manually or delete it to reset to presets).
 
     Returns:
-        Parsed voice registry dict.  Always a non-None mapping.
+        Parsed voice registry dict.  Always a non-None mapping.  When the user
+        file is schema-invalid, the bundled presets are returned instead of the
+        user data; the return value does not distinguish this substitution — check
+        logs if you need to detect the fallback.
 
     Raises:
         ValueError: If the loaded data is not a YAML mapping (dict).
+        ValueError: If the bundled presets themselves fail schema validation
+            (indicates a corrupt install; no fallback is possible).
     """
     if voices_file is None:
         user_voices = get_config_dir() / VOICES_FILENAME
@@ -166,8 +171,13 @@ def save_voices(data: dict[str, Any], voices_file: Path | None = None) -> None:
     behind but the original intact.
 
     Args:
-        data: Voice registry dict to serialise.
+        data: Voice registry dict to serialise.  Must pass
+            :func:`_validate_voices_schema` — invalid entries raise
+            ``ValueError`` before any file I/O occurs.
         voices_file: Destination path; defaults to user config.
+
+    Raises:
+        ValueError: If *data* contains schema-invalid voice entries.
     """
     if voices_file is None:
         voices_file = get_config_dir() / VOICES_FILENAME
@@ -205,12 +215,18 @@ def add_voice(
 
     Args:
         name: Voice key.
-        voice_data: Voice payload (must include ``type``).
+        voice_data: Voice payload (must include a valid ``type`` and satisfy
+            :func:`_validate_voices_schema`).  Invalid entries raise
+            ``ValueError`` via :func:`save_voices` before any write occurs.
         voices_file: Registry path; defaults to user config.
         allow_overwrite: If False, raise ``ValueError`` instead of
             overwriting an existing entry. Default True to preserve
             existing callers (`scripts/curate.py` intentionally
             replaces entries when re-exporting a clone).
+
+    Raises:
+        ValueError: If *name* already exists and *allow_overwrite* is False.
+        ValueError: If *voice_data* contains schema-invalid entries.
     """
     data = load_voices(voices_file)
     if "voices" not in data:

--- a/src/spanish_tts/config.py
+++ b/src/spanish_tts/config.py
@@ -140,6 +140,20 @@ def load_voices(voices_file: Path | None = None) -> dict[str, Any]:
             f"voices.yaml must be a YAML mapping (dict), got {type(data).__name__} in {voices_file}"
         )
 
+    try:
+        _validate_voices_schema(data, voices_file)
+    except ValueError as exc:
+        logger.error(
+            "Schema-invalid voices.yaml at %s: %s; falling back to bundled "
+            "presets. Fix or delete the file to restore normal operation.",
+            voices_file,
+            exc,
+        )
+        data = yaml.safe_load(DEFAULT_VOICES_FILE.read_text(encoding="utf-8"))
+        # Re-validate presets; if THOSE are broken the install is corrupt
+        # and we should raise.
+        _validate_voices_schema(data, DEFAULT_VOICES_FILE)
+
     return data
 
 
@@ -159,6 +173,7 @@ def save_voices(data: dict[str, Any], voices_file: Path | None = None) -> None:
         voices_file = get_config_dir() / VOICES_FILENAME
 
     voices_file.parent.mkdir(parents=True, exist_ok=True)
+    _validate_voices_schema(data, voices_file)
     tmp = voices_file.with_suffix(".yaml.tmp")
     with open(tmp, "w", encoding="utf-8") as fh:
         yaml.dump(data, fh, default_flow_style=False, allow_unicode=True, sort_keys=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -261,6 +261,14 @@ class TestLoadVoicesResilience:
         assert isinstance(data.get("voices"), dict)
         assert "neutral_male" in data["voices"]
 
+    def test_schema_invalid_load_does_not_overwrite_user_file(self, tmp_path):
+        """Schema-invalid user file is NOT modified by load_voices — user must recover manually."""
+        bad = tmp_path / VOICES_FILENAME
+        original_content = "voices:\n  bad_voice:\n    type: bogus\n    instruct: x\n"
+        bad.write_text(original_content, encoding="utf-8")
+        load_voices(bad)  # should not raise, should not overwrite
+        assert bad.read_text(encoding="utf-8") == original_content
+
 
 class TestSaveVoicesAtomic:
     def test_atomic_write_succeeds(self, tmp_path):
@@ -308,7 +316,8 @@ class TestSaveVoicesSchemaValidation:
             save_voices(invalid_data, vf)
         # No tmp file should have been written.
         assert not vf.with_suffix(".yaml.tmp").exists()
-        # Target file should not exist either.
+        # Validation fires before any I/O; target file was never created either.
+        # (This is vacuously true for a fresh tmp_path but documents intent.)
         assert not vf.exists()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -238,6 +238,29 @@ class TestLoadVoicesResilience:
         load_voices(bad)  # should not raise, should not overwrite
         assert bad.read_text(encoding="utf-8") == original_content
 
+    def test_load_voices_rejects_unknown_type(self, tmp_path, caplog):
+        """Voice with unknown type logs error and returns bundled presets (not raises)."""
+        bad = tmp_path / VOICES_FILENAME
+        bad.write_text(
+            "voices:\n  bogus_voice:\n    type: bogus\n    instruct: x\n", encoding="utf-8"
+        )
+        with caplog.at_level(logging.ERROR, logger="spanish_tts.config"):
+            data = load_voices(bad)
+        assert any("Schema-invalid" in r.message for r in caplog.records)
+        # Falls back to bundled presets.
+        assert isinstance(data.get("voices"), dict)
+        assert "neutral_male" in data["voices"]
+
+    def test_load_voices_rejects_missing_ref_audio(self, tmp_path, caplog):
+        """Clone voice without ref_audio logs error and returns bundled presets."""
+        bad = tmp_path / VOICES_FILENAME
+        bad.write_text("voices:\n  no_ref_clone:\n    type: clone\n", encoding="utf-8")
+        with caplog.at_level(logging.ERROR, logger="spanish_tts.config"):
+            data = load_voices(bad)
+        assert any("Schema-invalid" in r.message for r in caplog.records)
+        assert isinstance(data.get("voices"), dict)
+        assert "neutral_male" in data["voices"]
+
 
 class TestSaveVoicesAtomic:
     def test_atomic_write_succeeds(self, tmp_path):
@@ -265,15 +288,28 @@ class TestSaveVoicesAtomic:
 
         monkeypatch.setattr(os, "replace", boom)
         with pytest.raises(OSError, match="simulated disk-full"):
-            save_voices({"voices": {"corrupted": {}}}, vf)
+            save_voices({"voices": {"new_voice": {"type": "design", "instruct": "valid"}}}, vf)
 
-        # Original file unchanged; the "corrupted" key must NOT be present.
+        # Original file unchanged; the "new_voice" key must NOT be present.
         reloaded = load_voices(vf)
         assert "original" in reloaded["voices"]
-        assert "corrupted" not in reloaded["voices"]
+        assert "new_voice" not in reloaded["voices"]
         # The tmp file may remain on disk after a failed replace — that is
         # acceptable (it won't be confused with the real file due to the .tmp
         # suffix), but the original target must be intact.
+
+
+class TestSaveVoicesSchemaValidation:
+    def test_save_voices_rejects_invalid_schema(self, tmp_path):
+        """save_voices raises ValueError for invalid schema BEFORE writing tmp file."""
+        vf = tmp_path / VOICES_FILENAME
+        invalid_data = {"voices": {"bad_voice": {"type": "bogus", "instruct": "x"}}}
+        with pytest.raises(ValueError, match="invalid type"):
+            save_voices(invalid_data, vf)
+        # No tmp file should have been written.
+        assert not vf.with_suffix(".yaml.tmp").exists()
+        # Target file should not exist either.
+        assert not vf.exists()
 
 
 class TestVoicesSchemaValidation:


### PR DESCRIPTION
## WHY

REVIEW FOUND THE VALIDATOR WAS DEAD CODE — DEFINED AND TESTED BUT NEVER CALLED FROM `load_voices`/`save_voices`/`add_voice`. MALFORMED VOICE ENTRIES PASSED THROUGH UNCHECKED IN PRODUCTION.

## WHAT

- `load_voices()` — CALLS `_validate_voices_schema` AFTER YAML PARSE + dict CHECK. ON FAILURE: LOGS ERROR, FALLS BACK TO BUNDLED PRESETS (MIRRORS YAMLError HANDLING). CORRUPT USER FILE NOT OVERWRITTEN.
- `save_voices()` — CALLS `_validate_voices_schema` BEFORE ATOMIC WRITE. INVALID DATA RAISES ValueError, NO TMP FILE WRITTEN.
- `add_voice` — COVERED TRANSITIVELY (CALLS BOTH ABOVE). NO DIRECT EDIT.
- TESTS: 3 NEW TESTS (`test_load_voices_rejects_unknown_type`, `test_load_voices_rejects_missing_ref_audio`, `test_save_voices_rejects_invalid_schema`). UPDATED `test_atomic_failure_leaves_original_intact` TO USE VALID DATA (SCHEMA NOW REJECTS INVALID DATA BEFORE os.replace).
- CHANGELOG: `### Fixed` + `### Changed` MIGRATION NOTE ADDED.

## TEST

- 192 PASSED (WAS 189, +3 NEW TESTS).
- ALL 6 EXISTING `TestVoicesSchemaValidation` TESTS STILL PASS.
- pre-commit CLEAN.

## RISK / ROLLBACK

- MIGRATION: USER WHOSE `voices.yaml` WAS VALID YAML BUT SCHEMA-INVALID WILL NOW SEE LOGGED ERROR + PRESET FALLBACK. PREVIOUS: SILENT PASS. DOCUMENTED IN CHANGELOG.
- ROLLBACK: `git revert` THIS COMMIT. SCHEMA VALIDATOR REVERTS TO DEAD CODE.

CLOSES HOTFIX IN #15.