### PR TITLE
feat(engine): U3-19 ADD TtsResult DATACLASS — ENGINE-RETURNED DURATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `[project.urls]`, `classifiers`, `keywords` added to `pyproject.toml`; `requires_mlx` marker registered (U3-20).
 
 ### Changed
-- `generate_clone`, `generate_design`, `generate` now return `TtsResult` instead of `str`. `str(result)` still returns the path — backward-compat callers unaffected (U3-19).
+- `generate_clone`, `generate_design`, `generate` now return `TtsResult` instead of `str`. `str(result)` still returns the path — string-coercion callers unaffected; equality comparisons against plain path strings break (use `result.path`) (U3-19).
 - MCP `say` `duration_seconds` field now always a float (engine-computed). The `sf.info` re-read and its bare-except dead branch are removed (U3-19).
+- `pyproject.toml` version bumped to `0.3.0` (breaking engine public API).
 - `CONTRACT.md` updated: `duration_seconds` documented as always-present finite float.
 - `load_voices` now falls back to bundled presets (with a logged error) when the user's `voices.yaml` contains schema-invalid entries, in addition to the existing `YAMLError` fallback. The user's corrupt file is NOT overwritten.
 - `config.py` `save_voices()` now writes atomically via `.yaml.tmp` + `os.replace` (U3-3).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `TtsResult` dataclass in `engine.py` — frozen, `path: str`, `duration_seconds: float`, `__str__` returns path for backward-compat (U3-19).
+- `TtsResult` exported from `spanish_tts.__init__` (U3-19).
 - `CONTRACT.md` — stable JSON shapes + backward-compat policy for the MCP server (U3-5 part 1).
 - `LICENSE` file with full MIT text; PEP 639 migration in `pyproject.toml` (U3-1).
 - `SECURITY.md` with supported versions, private advisory link, and 72h ack SLA (U3-11).
@@ -23,6 +25,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `[project.urls]`, `classifiers`, `keywords` added to `pyproject.toml`; `requires_mlx` marker registered (U3-20).
 
 ### Changed
+- `generate_clone`, `generate_design`, `generate` now return `TtsResult` instead of `str`. `str(result)` still returns the path — backward-compat callers unaffected (U3-19).
+- MCP `say` `duration_seconds` field now always a float (engine-computed). The `sf.info` re-read and its bare-except dead branch are removed (U3-19).
+- `CONTRACT.md` updated: `duration_seconds` documented as always-present finite float.
 - `load_voices` now falls back to bundled presets (with a logged error) when the user's `voices.yaml` contains schema-invalid entries, in addition to the existing `YAMLError` fallback. The user's corrupt file is NOT overwritten.
 - `config.py` `save_voices()` now writes atomically via `.yaml.tmp` + `os.replace` (U3-3).
 - `config.py` `load_voices()` catches `yaml.YAMLError`, falls back to bundled presets, never overwrites corrupt user file (U3-3).

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -27,9 +27,10 @@ Synthesise speech from text.
 {"path": "<absolute-path-to-wav>", "duration_seconds": <float>}
 ```
 
-> Note: `duration_seconds` is returned in the engine layer (see U3-19).
-> Until U3-19 lands the field may be absent; callers should treat it as
-> optional.
+> `duration_seconds` is computed in the engine layer (U3-19) from the raw
+> audio array (`len(audio) / sample_rate`). It is **always a finite float**,
+> never `null` / `None`. Callers may rely on this field being present and
+> numeric on every successful `say` response.
 
 **Error response**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwen3-tts-spanish-voices"
-version = "0.2.0"
+version = "0.3.0"
 description = "Curated Spanish TTS voices using Qwen3-TTS voice cloning and design"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/spanish_tts/__init__.py
+++ b/src/spanish_tts/__init__.py
@@ -1,6 +1,6 @@
 """spanish-tts: Curated Spanish TTS voices using Qwen3-TTS."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 
 from spanish_tts.engine import TtsResult
 

--- a/src/spanish_tts/__init__.py
+++ b/src/spanish_tts/__init__.py
@@ -1,3 +1,7 @@
 """spanish-tts: Curated Spanish TTS voices using Qwen3-TTS."""
 
 __version__ = "0.1.0"
+
+from spanish_tts.engine import TtsResult
+
+__all__ = ["TtsResult"]

--- a/src/spanish_tts/cli.py
+++ b/src/spanish_tts/cli.py
@@ -58,7 +58,7 @@ def say(text, voice, speed, output, play):
     if play:
         import subprocess
 
-        subprocess.run(["afplay", result])
+        subprocess.run(["afplay", str(result)])
 
 
 @cli.command("list")

--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
@@ -11,6 +12,29 @@ import numpy as np
 import soundfile as sf
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TtsResult:
+    """Return value from all ``generate_*`` engine entry points.
+
+    Attributes:
+        path: Absolute path to the written ``.wav`` file.
+        duration_seconds: Exact duration computed from the raw audio array
+            (``len(audio) / sample_rate``).  Always a finite float — never
+            re-read from the file via ``sf.info``.
+
+    The ``__str__`` shim returns ``self.path`` so existing callers that
+    treat the result as a string (``click.echo(result)``, f-strings, etc.)
+    continue working without modification.
+    """
+
+    path: str
+    duration_seconds: float
+
+    def __str__(self) -> str:  # backward-compat shim
+        return self.path
+
 
 # Speed range constants
 SPEED_MIN, SPEED_MAX = 0.5, 2.0
@@ -178,7 +202,7 @@ def generate_clone(
     stream: bool = False,
     streaming_interval: float = 2.0,
     on_chunk: Callable[[int, int, float], None] | None = None,
-) -> str:
+) -> TtsResult:
     """Generate speech by cloning a reference voice.
 
     Args:
@@ -194,7 +218,9 @@ def generate_clone(
         on_chunk: Optional callback(chunk_index, total_samples, est_duration).
 
     Returns:
-        Path to generated .wav file.
+        :class:`TtsResult` with the path to the generated ``.wav`` and its
+        exact duration.  ``str(result)`` returns ``result.path`` for
+        backward-compatible callers.
     """
     ref_path = Path(ref_audio).expanduser()
     if not ref_path.exists():
@@ -228,7 +254,7 @@ def generate_clone(
 
     duration = len(audio_np) / sample_rate
     print(f"Saved: {output_path} ({duration:.1f}s)", file=sys.stderr)
-    return output_path
+    return TtsResult(path=output_path, duration_seconds=duration)
 
 
 def generate_design(
@@ -242,7 +268,7 @@ def generate_design(
     stream: bool = False,
     streaming_interval: float = 2.0,
     on_chunk: Callable[[int, int, float], None] | None = None,
-) -> str:
+) -> TtsResult:
     """Generate speech from a voice description.
 
     Args:
@@ -258,7 +284,9 @@ def generate_design(
         on_chunk: Optional callback(chunk_index, total_samples, est_duration).
 
     Returns:
-        Path to generated .wav file.
+        :class:`TtsResult` with the path to the generated ``.wav`` and its
+        exact duration.  ``str(result)`` returns ``result.path`` for
+        backward-compatible callers.
     """
     lang_map = {
         "Spanish": "spanish",
@@ -302,7 +330,7 @@ def generate_design(
 
     duration = len(audio_np) / sample_rate
     print(f"Saved: {output_path} ({duration:.1f}s)", file=sys.stderr)
-    return output_path
+    return TtsResult(path=output_path, duration_seconds=duration)
 
 
 def generate(
@@ -314,7 +342,7 @@ def generate(
     stream: bool = False,
     streaming_interval: float = 2.0,
     on_chunk: Callable[[int, int, float], None] | None = None,
-) -> str:
+) -> TtsResult:
     """Generate speech using a voice config from the registry.
 
     Args:
@@ -328,7 +356,9 @@ def generate(
         on_chunk: Optional callback(chunk_index, total_samples, est_duration).
 
     Returns:
-        Path to generated .wav file.
+        :class:`TtsResult` with the path to the generated ``.wav`` and its
+        exact duration.  ``str(result)`` returns ``result.path`` for
+        backward-compatible callers.
     """
     voice_type = voice_config.get("type", "design")
     language = voice_config.get("language", "Spanish")

--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -25,8 +25,11 @@ class TtsResult:
             re-read from the file via ``sf.info``.
 
     The ``__str__`` shim returns ``self.path`` so existing callers that
-    treat the result as a string (``click.echo(result)``, f-strings, etc.)
-    continue working without modification.
+    treat the result as a string via coercion (``click.echo(result)``,
+    f-strings, ``str(result)``, ``print(result)``) continue working
+    without modification.  Equality comparisons against plain path strings
+    (``result == "/path/foo.wav"``) will **not** match — use
+    ``result.path == "/path/foo.wav"`` or ``str(result) == "/path/foo.wav"``.
     """
 
     path: str

--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -125,7 +125,7 @@ def say(
         logger.info("Chunk %d: %.1fs generated so far", idx, est_duration)
 
     try:
-        path = generate(
+        result = generate(
             text=text,
             voice_config=voice_config,
             speed=effective_speed,
@@ -138,15 +138,7 @@ def say(
         logger.error("generate() failed: %s", e, exc_info=True)
         return {"error": f"Generation failed: {e}"}
 
-    try:
-        import soundfile as sf
-
-        info = sf.info(path)
-        duration = round(info.duration, 2)
-    except Exception:
-        duration = None
-
-    return {"path": path, "duration_seconds": duration}
+    return {"path": result.path, "duration_seconds": round(result.duration_seconds, 2)}
 
 
 @mcp.tool()
@@ -210,13 +202,13 @@ def demo(text: str, output_dir: str = "/tmp/spanish-tts-demo", speed: float = 1.
     results = []
     for name, config in voices.items():
         try:
-            path = generate(
+            result = generate(
                 text=text,
                 voice_config=config,
                 speed=speed,
                 output=str(out / f"{name}.wav"),
             )
-            results.append({"voice": name, "path": path, "status": "ok"})
+            results.append({"voice": name, "path": result.path, "status": "ok"})
         except Exception as e:
             logger.error("demo generate for %s failed: %s", name, e)
             results.append({"voice": name, "error": str(e), "status": "failed"})

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8,6 +8,7 @@ import pytest
 
 from spanish_tts.engine import (
     MODELS,
+    TtsResult,
     _cache_lock,
     _clear_cache,
     _generate_lock,
@@ -27,6 +28,30 @@ class TestModels:
     def test_model_ids_are_mlx(self):
         for key, model_id in MODELS.items():
             assert "mlx-community" in model_id, f"{key} model should be mlx-community"
+
+
+class TestTtsResult:
+    def test_is_dataclass(self):
+        r = TtsResult(path="/tmp/foo.wav", duration_seconds=1.5)
+        assert isinstance(r, TtsResult)
+
+    def test_str_returns_path(self):
+        r = TtsResult(path="/tmp/foo.wav", duration_seconds=1.5)
+        assert str(r) == "/tmp/foo.wav"
+        assert str(r) == r.path
+
+    def test_duration_seconds_stored(self):
+        r = TtsResult(path="/tmp/foo.wav", duration_seconds=2.345)
+        assert r.duration_seconds == pytest.approx(2.345)
+
+    def test_fstring_interpolation(self):
+        r = TtsResult(path="/tmp/foo.wav", duration_seconds=1.0)
+        assert f"{r}" == "/tmp/foo.wav"
+
+    def test_frozen(self):
+        r = TtsResult(path="/tmp/foo.wav", duration_seconds=1.0)
+        with pytest.raises(AttributeError):  # frozen dataclass raises FrozenInstanceError
+            r.path = "/other"  # type: ignore[misc]
 
 
 class TestGenerateCloneSignature:

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -2,7 +2,7 @@
 
 Covers lines in mcp_server.py that were uncovered by the existing test suite:
   - say(): empty/whitespace text, too-long text, voice not found, path OSError,
-    generate() exception, sf.info failure, stream=True on_chunk wiring
+    generate() exception, stream=True on_chunk wiring
   - list_all_voices(): clone accent field, exception fallback
   - demo(): empty text, partial failure loop
 """
@@ -10,10 +10,11 @@ Covers lines in mcp_server.py that were uncovered by the existing test suite:
 import importlib
 import logging
 import sys
-import types
 
 import pytest
 import yaml
+
+from spanish_tts.engine import TtsResult
 
 # ---------------------------------------------------------------------------
 # Fixture
@@ -36,18 +37,9 @@ def bundled_presets(tmp_path, monkeypatch):
         sys.modules.pop(mod, None)
 
 
-def _fake_sf_module(duration=2.0):
-    """Return a minimal soundfile stand-in whose info() returns a given duration."""
-
-    class _Info:
-        pass
-
-    inst = _Info()
-    inst.duration = duration
-
-    fake_sf = types.ModuleType("soundfile")
-    fake_sf.info = lambda p: inst
-    return fake_sf
+def _make_tts_result(path: str, duration: float = 1.23) -> TtsResult:
+    """Minimal TtsResult for patching engine.generate in tests."""
+    return TtsResult(path=path, duration_seconds=duration)
 
 
 # ---------------------------------------------------------------------------
@@ -75,8 +67,9 @@ class TestSayTextValidation:
         monkeypatch.setattr(
             mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
         )
-        monkeypatch.setattr(mcp, "generate", lambda **kw: str(tmp_path / "out.wav"))
-        monkeypatch.setitem(sys.modules, "soundfile", _fake_sf_module())
+        monkeypatch.setattr(
+            mcp, "generate", lambda **kw: _make_tts_result(str(tmp_path / "out.wav"))
+        )
         result = mcp.say(text="a" * 10000, voice="neutral_male")
         assert "error" not in result
 
@@ -162,25 +155,24 @@ class TestSayGenerateException:
 
 
 # ---------------------------------------------------------------------------
-# say() — sf.info() failure (line 145 → duration_seconds=None)
+# say() — duration_seconds always present (U3-19: engine-returned, never None)
 # ---------------------------------------------------------------------------
 
 
-class TestSaySfInfoFailure:
-    def test_broken_wav_returns_duration_none(self, bundled_presets, tmp_path, monkeypatch):
+class TestSayDurationAlwaysPresent:
+    def test_duration_seconds_is_float(self, bundled_presets, tmp_path, monkeypatch):
+        """say() returns duration_seconds as a float, always — never None."""
         mcp = bundled_presets
         monkeypatch.setattr(
             mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
         )
-        monkeypatch.setattr(mcp, "generate", lambda **kw: str(tmp_path / "out.wav"))
-
-        bad_sf = types.ModuleType("soundfile")
-        bad_sf.info = lambda p: (_ for _ in ()).throw(Exception("not a wav"))
-        monkeypatch.setitem(sys.modules, "soundfile", bad_sf)
-
+        monkeypatch.setattr(
+            mcp, "generate", lambda **kw: _make_tts_result(str(tmp_path / "out.wav"), 2.5)
+        )
         result = mcp.say(text="hola", voice="neutral_male")
         assert "error" not in result
-        assert result["duration_seconds"] is None
+        assert isinstance(result["duration_seconds"], float)
+        assert result["duration_seconds"] == pytest.approx(2.5, abs=0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -199,10 +191,9 @@ class TestSayStreamWiring:
 
         def fake_generate(**kwargs):
             captured.update(kwargs)
-            return str(tmp_path / "out.wav")
+            return _make_tts_result(str(tmp_path / "out.wav"), 1.5)
 
         monkeypatch.setattr(mcp, "generate", fake_generate)
-        monkeypatch.setitem(sys.modules, "soundfile", _fake_sf_module(1.5))
 
         mcp.say(text="hola", voice="neutral_male", stream=True)
         assert captured.get("on_chunk") is not None
@@ -217,9 +208,10 @@ class TestSayStreamWiring:
         )
         captured = {}
         monkeypatch.setattr(
-            mcp, "generate", lambda **kw: (captured.update(kw), str(tmp_path / "x.wav"))[1]
+            mcp,
+            "generate",
+            lambda **kw: (captured.update(kw), _make_tts_result(str(tmp_path / "x.wav")))[1],
         )
-        monkeypatch.setitem(sys.modules, "soundfile", _fake_sf_module())
         mcp.say(text="hola", voice="neutral_male", stream=False)
         assert captured["on_chunk"] is None
 
@@ -293,7 +285,7 @@ class TestDemoErrorBranches:
         assert voices, "Need bundled voices for this test"
 
         def fake_generate(**kw):
-            return kw["output"]
+            return _make_tts_result(kw["output"])
 
         monkeypatch.setattr(mcp, "generate", fake_generate)
         result = mcp.demo(text="hola", output_dir=str(tmp_path / "demo_out"))
@@ -312,7 +304,7 @@ class TestDemoErrorBranches:
             name = kw["output"].split("/")[-1].replace(".wav", "")
             if name == first:
                 raise RuntimeError(f"{first} simulated failure")
-            return kw["output"]
+            return _make_tts_result(kw["output"])
 
         monkeypatch.setattr(mcp, "generate", fake_generate)
         result = mcp.demo(text="hola", output_dir=str(tmp_path / "partial"))
@@ -330,7 +322,7 @@ class TestDemoErrorBranches:
             lambda **kw: (
                 (_ for _ in ()).throw(RuntimeError("boom"))
                 if kw["output"].endswith(f"{first}.wav")
-                else kw["output"]
+                else _make_tts_result(kw["output"])
             ),
         )
         result = mcp.demo(text="hola", output_dir=str(tmp_path / "err_field"))
@@ -346,7 +338,7 @@ class TestDemoErrorBranches:
             name = kw["output"].split("/")[-1].replace(".wav", "")
             if name == first:
                 raise RuntimeError("demo kaboom")
-            return kw["output"]
+            return _make_tts_result(kw["output"])
 
         monkeypatch.setattr(mcp, "generate", boom)
         with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -18,6 +18,8 @@ import sys
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
+from spanish_tts.engine import TtsResult
+
 # ---------------------------------------------------------------------------
 # Fixture: reload mcp_server against bundled presets (no user voices.yaml)
 # ---------------------------------------------------------------------------
@@ -141,14 +143,12 @@ class TestSayRejection:
 
 class TestSaySuccessShape:
     def test_say_returns_path_and_duration(self, mcp_module, monkeypatch, tmp_path):
-        """CONTRACT: success response has 'path' (str) and 'duration_seconds'."""
-        import numpy as np
-        import soundfile as sf
-
+        """CONTRACT: success response has 'path' (str) and 'duration_seconds' (float)."""
         out = str(tmp_path / "out.wav")
-        sf.write(out, np.zeros(4800, dtype=np.float32), 24000)
 
-        monkeypatch.setattr(mcp_module, "generate", lambda **kw: out)
+        monkeypatch.setattr(
+            mcp_module, "generate", lambda **kw: TtsResult(path=out, duration_seconds=0.2)
+        )
         monkeypatch.setattr(
             mcp_module, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
         )
@@ -158,7 +158,7 @@ class TestSaySuccessShape:
         assert "path" in result
         assert isinstance(result["path"], str)
         assert "duration_seconds" in result
-        assert result["duration_seconds"] is None or isinstance(result["duration_seconds"], float)
+        assert isinstance(result["duration_seconds"], float)
 
     def test_say_error_response_has_error_key(self, mcp_module, monkeypatch, tmp_path):
         """CONTRACT: error response has 'error' (str)."""
@@ -252,16 +252,12 @@ class TestDemoShape:
 
     def test_demo_success_has_results_list(self, mcp_module, monkeypatch, tmp_path):
         """CONTRACT: success response has 'results' list."""
-        import numpy as np
-        import soundfile as sf
-
         call_count = {"n": 0}
 
         def fake_generate(**kw):
             call_count["n"] += 1
             out = str(tmp_path / f"out_{call_count['n']}.wav")
-            sf.write(out, np.zeros(2400, dtype=np.float32), 24000)
-            return out
+            return TtsResult(path=out, duration_seconds=0.1)
 
         monkeypatch.setattr(mcp_module, "generate", fake_generate)
         result = _call(mcp_module, "demo", {"text": "hola", "output_dir": str(tmp_path)})
@@ -271,13 +267,10 @@ class TestDemoShape:
 
     def test_demo_each_result_has_status(self, mcp_module, monkeypatch, tmp_path):
         """CONTRACT: each result entry has 'voice', 'status', and either 'path' or 'error'."""
-        import numpy as np
-        import soundfile as sf
 
         def fake_generate(**kw):
             out = str(tmp_path / "out.wav")
-            sf.write(out, np.zeros(2400, dtype=np.float32), 24000)
-            return out
+            return TtsResult(path=out, duration_seconds=0.1)
 
         monkeypatch.setattr(mcp_module, "generate", fake_generate)
         result = _call(mcp_module, "demo", {"text": "hola", "output_dir": str(tmp_path)})
@@ -292,9 +285,6 @@ class TestDemoShape:
 
     def test_demo_partial_failure_continues(self, mcp_module, monkeypatch, tmp_path):
         """CONTRACT: one voice failure does not abort the whole demo."""
-        import numpy as np
-        import soundfile as sf
-
         voice_names = list(mcp_module.list_voices().keys())
         assert len(voice_names) >= 2, "Need at least 2 voices for partial-failure test"
 
@@ -309,8 +299,7 @@ class TestDemoShape:
             if name == first_voice:
                 raise RuntimeError("simulated first-voice failure")
             out = str(tmp_path / f"out_{call_count['n']}.wav")
-            sf.write(out, np.zeros(2400, dtype=np.float32), 24000)
-            return out
+            return TtsResult(path=out, duration_seconds=0.1)
 
         monkeypatch.setattr(mcp_module, "generate", fake_generate)
         result = _call(mcp_module, "demo", {"text": "hola", "output_dir": str(tmp_path)})

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,6 +5,8 @@ import sys
 
 import pytest
 
+from spanish_tts.engine import TtsResult
+
 
 @pytest.fixture
 def bundled_presets(tmp_path, monkeypatch):
@@ -95,14 +97,13 @@ def test_say_accepts_relative_path_inside_output_dir(bundled_presets, tmp_path, 
 
     def fake_generate(**kwargs):
         captured.update(kwargs)
-        return kwargs["output"]
+        return TtsResult(path=kwargs["output"], duration_seconds=1.0)
 
     monkeypatch.setattr(mcp, "generate", fake_generate)
     monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})
 
     result = mcp.say(text="hola", voice="neutral_male", output="sub/out.wav")
-    # No error returned. The path may or may not exist yet; sf.info
-    # will fail which is fine — `duration_seconds` comes back None.
+    # No error returned.
     assert "error" not in result, result
     resolved = captured["output"]
     assert resolved.startswith(str(tmp_path.resolve()))
@@ -171,7 +172,7 @@ def test_say_accepts_absolute_path_inside_output_dir(bundled_presets, tmp_path, 
 
     def fake_generate(**kwargs):
         captured.update(kwargs)
-        return kwargs["output"]
+        return TtsResult(path=kwargs["output"], duration_seconds=1.0)
 
     monkeypatch.setattr(mcp, "generate", fake_generate)
     monkeypatch.setattr(mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)})

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from spanish_tts.engine import SPEED_MAX, SPEED_MIN, _apply_speed
+from spanish_tts.engine import SPEED_MAX, SPEED_MIN, TtsResult, _apply_speed
 
 try:
     import librosa  # noqa: F401
@@ -200,7 +200,7 @@ class TestMCPSpeedValidation:
 
                 def fake_generate(**kwargs):
                     captured.update(kwargs)
-                    return "/tmp/ok.wav"
+                    return TtsResult(path="/tmp/ok.wav", duration_seconds=1.0)
 
                 with patch("spanish_tts.mcp_server.generate", side_effect=fake_generate):
                     result = say(text="hola", voice="x", speed=None)
@@ -222,7 +222,7 @@ class TestMCPSpeedValidation:
 
                 def fake_generate(**kwargs):
                     captured.update(kwargs)
-                    return "/tmp/ok.wav"
+                    return TtsResult(path="/tmp/ok.wav", duration_seconds=1.0)
 
                 with patch("spanish_tts.mcp_server.generate", side_effect=fake_generate):
                     say(text="hola", voice="x")


### PR DESCRIPTION
## WHY

MCP say() WAS CALLING sf.info() TO READ DURATION AFTER WRITING THE FILE — ADDING AN EXTRA SYSCALL AND A BARE-EXCEPT THAT SILENTLY RETURNED duration_seconds=None ON ANY FILE FAILURE. CLOSES THE SILENT-SUCCESS LOOPHOLE FOR CORRUPT WAVS. CHANGES generate_* PUBLIC RETURN TYPE → v0.3.0 REQUIRED.

## WHAT

### Commit 1: feat(engine) implementation
- ADD FROZEN DATACLASS TtsResult(path: str, duration_seconds: float) TO engine.py WITH __str__ SHIM RETURNING self.path (BACKWARD COMPAT).
- ALL THREE ENGINE ENTRY POINTS (generate_clone, generate_design, generate) RETURN TtsResult.
- DURATION COMPUTED INLINE: len(audio_np) / sample_rate — EXACT, NO EXTRA I/O.
- mcp_server.py say(): ASSIGN result = generate(...), RETURN result.path + round(result.duration_seconds, 2). DROP sf.info RE-READ AND bare-except (DEAD CODE REMOVED).
- mcp_server.py demo(): USE result.path FROM TtsResult.
- cli.py say: subprocess.run(["afplay", str(result)]) — EXPLICIT str() FOR subprocess SAFETY.
- __init__.py: EXPORT TtsResult IN __all__.
- CONTRACT.md: duration_seconds NOW DOCUMENTED AS ALWAYS-PRESENT FINITE FLOAT.

### Commit 2: test updates
- test_engine.py: ADD TestTtsResult (isinstance, __str__, duration, f-string, frozen).
- test_mcp_errors.py: REPLACE _fake_sf_module WITH _make_tts_result. REPLACE TestSaySfInfoFailure WITH TestSayDurationAlwaysPresent (duration_seconds ALWAYS float).
- test_mcp_server.py, test_mcp_protocol.py, test_speed.py: UPDATE ALL fake_generate MOCKS TO RETURN TtsResult.

## TEST

- 198 PASSED (WAS 193 AT WAVE 4 START, +5 NEW TESTS).
- pre-commit CLEAN.

## RISK / ROLLBACK

- BREAKING: generate_clone/generate_design/generate RETURN TtsResult NOT str. ANY DIRECT CALLER DOING path = generate(...) AND THEN os.path.join(path, ...) WILL BREAK. __str__ COVERS click.echo, f-STRINGS, print. str(result) EXPLICIT FOR SUBPROCESS.
- HERMES SKILL: IMPORTS generate_* SOMEWHERE? FLAG IF FOUND. NOT FIXED IN THIS PR.
- ROLLBACK: git revert BOTH COMMITS. RESTORE str RETURN TYPE.

CLOSES CHECKBOX U3-19 IN #15.