### PR TITLE
feat(engine): U3-17 CLI/MCP PARITY SWEEP + ECO-016 ERROR CODE FIELD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `_validate_text` helper in `engine.py` — rejects empty/NUL/too-long text with `ValueError`. Called from `generate_clone` and `generate_design` (U3-17).
 - `TtsResult` dataclass in `engine.py` — frozen, `path: str`, `duration_seconds: float`, `__str__` returns path for backward-compat (U3-19).
 - `TtsResult` exported from `spanish_tts.__init__` (U3-19).
 - `CONTRACT.md` — stable JSON shapes + backward-compat policy for the MCP server (U3-5 part 1).
@@ -27,6 +28,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - `generate_clone`, `generate_design`, `generate` now return `TtsResult` instead of `str`. `str(result)` still returns the path — string-coercion callers unaffected; equality comparisons against plain path strings break (use `result.path`) (U3-19).
 - MCP `say` `duration_seconds` field now always a float (engine-computed). The `sf.info` re-read and its bare-except dead branch are removed (U3-19).
+- MCP `say`/`demo` error responses now include a stable `code` field alongside `error`. Stable enum documented in `CONTRACT.md` (U3-17, ECO-016).
+- MCP `say` rejects NUL bytes in `text` (`text_nul` code) and adds `math.isfinite` guard on speed before the range check (`speed_not_finite` code) (U3-17).
+- CLI `say` speed fallback: `speed or defaults.get(...)` replaced by `speed if speed is not None else ...` — prevents `speed=0.0` falling through (U3-17).
 - `pyproject.toml` version bumped to `0.3.0` (breaking engine public API).
 - `CONTRACT.md` updated: `duration_seconds` documented as always-present finite float.
 - `load_voices` now falls back to bundled presets (with a logged error) when the user's `voices.yaml` contains schema-invalid entries, in addition to the existing `YAMLError` fallback. The user's corrupt file is NOT overwritten.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -56,6 +56,7 @@ The `code` field is **stable** — callers should branch on `code`, not `error`.
 | `path_is_dir` | `output` resolves to `output_dir` itself (a directory) |
 | `generation_failed` | engine raised an unexpected exception |
 | `voices_empty` | `demo` called with zero registered voices |
+| `internal_error` | unexpected exception in a non-generation tool handler (e.g. config read failure in `list_all_voices`) |
 
 ---
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -32,22 +32,30 @@ Synthesise speech from text.
 > never `null` / `None`. Callers may rely on this field being present and
 > numeric on every successful `say` response.
 
-**Error response**
+**Error response** (U3-17: `code` field added)
 
 ```json
-{"error": "<human-readable message>"}
+{"error": "<human-readable message>", "code": "<stable-enum>"}
 ```
 
-Known error messages (stable strings):
+The `error` string is human-readable and may change across versions.
+The `code` field is **stable** — callers should branch on `code`, not `error`.
 
-| Condition | `error` value |
-|-----------|--------------|
-| Text is empty / whitespace-only | `"text is empty"` |
-| Text contains NUL byte | `"text contains NUL byte"` |
-| Text exceeds 10 000 characters | `"text too long (N chars, max 10000)"` |
-| Voice not found in registry | `"voice '<name>' not found"` |
-| Output path outside safe root | `"output path not allowed"` |
-| Generation engine failure | `"generation failed: <reason>"` |
+### Error sentinel — `code` values
+
+| `code` | Returned when |
+|---|---|
+| `text_empty` | `text` is `None`, empty, or whitespace-only |
+| `text_nul` | `text` contains a NUL byte (`\x00`) |
+| `text_too_long` | `text` exceeds 10 000 characters |
+| `voice_not_found` | `voice` is not registered |
+| `speed_out_of_range` | `speed` outside 0.5–2.0 |
+| `speed_not_finite` | `speed` is NaN or ±infinity |
+| `path_invalid` | `output` is an empty string, contains NUL, or cannot be resolved |
+| `path_escape` | `output` resolves outside `output_dir` (path-traversal attempt) |
+| `path_is_dir` | `output` resolves to `output_dir` itself (a directory) |
+| `generation_failed` | engine raised an unexpected exception |
+| `voices_empty` | `demo` called with zero registered voices |
 
 ---
 
@@ -78,7 +86,7 @@ Return all registered voices.
 **Error response**
 
 ```json
-{"error": "<human-readable message>"}
+{"error": "<human-readable message>", "code": "<stable-enum>"}
 ```
 
 ---
@@ -115,7 +123,7 @@ Partial failure is normal: if one voice fails the others still run.
 **Error response** (whole-tool failure, not per-voice)
 
 ```json
-{"error": "<human-readable message>"}
+{"error": "<human-readable message>", "code": "<stable-enum>"}
 ```
 
 ---

--- a/src/spanish_tts/cli.py
+++ b/src/spanish_tts/cli.py
@@ -42,7 +42,7 @@ def say(text, voice, speed, output, play):
         click.echo(f"Available: {', '.join(available)}", err=True)
         raise SystemExit(1)
 
-    effective_speed = speed or defaults.get("speed", 1.0)
+    effective_speed = speed if speed is not None else defaults.get("speed", 1.0)
     output_dir = defaults.get("output_dir", "~/tts-output/spanish")
 
     result = generate(

--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -42,6 +42,33 @@ class TtsResult:
 # Speed range constants
 SPEED_MIN, SPEED_MAX = 0.5, 2.0
 
+_MAX_TEXT_LEN = 10_000
+
+
+def _validate_text(text: str, max_len: int | None = _MAX_TEXT_LEN) -> str:
+    """Validate text before synthesis.  Returns *text* unchanged on success.
+
+    Args:
+        text: Text to validate.
+        max_len: Maximum allowed character count (default 10 000).  Pass
+            ``None`` to skip the length check.
+
+    Returns:
+        The *text* argument unchanged (convenience for inline use).
+
+    Raises:
+        ValueError: If the text is empty/whitespace-only, contains a NUL
+            byte, or exceeds *max_len* characters.
+    """
+    if text is None or not text.strip():
+        raise ValueError("text is empty")
+    if "\x00" in text:
+        raise ValueError("text contains NUL byte")
+    if max_len is not None and len(text) > max_len:
+        raise ValueError(f"text too long ({len(text)} chars, max {max_len})")
+    return text
+
+
 # Default MLX models
 MODELS = {
     "clone": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit",
@@ -225,6 +252,7 @@ def generate_clone(
         exact duration.  ``str(result)`` returns ``result.path`` for
         backward-compatible callers.
     """
+    _validate_text(text)
     ref_path = Path(ref_audio).expanduser()
     if not ref_path.exists():
         raise FileNotFoundError(f"Reference audio not found: {ref_path}")
@@ -291,6 +319,7 @@ def generate_design(
         exact duration.  ``str(result)`` returns ``result.path`` for
         backward-compatible callers.
     """
+    _validate_text(text)
     lang_map = {
         "Spanish": "spanish",
         "English": "english",

--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -14,6 +14,7 @@ Hermes config.yaml:
 """
 
 import logging
+import math
 import sys
 from pathlib import Path
 
@@ -55,22 +56,39 @@ def say(
         stream: Use streaming decode for lower memory on long texts (default: false).
 
     Returns:
-        Dict with 'path' and 'duration_seconds', or 'error'.
+        Dict with 'path' and 'duration_seconds', or {'error': ..., 'code': ...}.
+        The 'code' key is a stable enum value (see CONTRACT.md).
     """
     if not text or not text.strip():
-        return {"error": "text is empty"}
+        return {"error": "text is empty", "code": "text_empty"}
+    if "\x00" in text:
+        return {"error": "text contains NUL byte", "code": "text_nul"}
     if len(text) > 10000:
-        return {"error": f"text too long ({len(text)} chars, max 10000)"}
+        return {
+            "error": f"text too long ({len(text)} chars, max 10000)",
+            "code": "text_too_long",
+        }
 
     voice_config = get_voice(voice)
     if voice_config is None:
         available = list(list_voices().keys())
-        return {"error": f"Voice '{voice}' not found. Available: {', '.join(available)}"}
+        return {
+            "error": f"Voice '{voice}' not found. Available: {', '.join(available)}",
+            "code": "voice_not_found",
+        }
 
     defaults = get_defaults()
     effective_speed = speed if speed is not None else defaults.get("speed", 1.0)
+    if not math.isfinite(effective_speed):
+        return {
+            "error": f"speed must be a finite number, got {effective_speed}",
+            "code": "speed_not_finite",
+        }
     if not (0.5 <= effective_speed <= 2.0):
-        return {"error": f"speed out of range 0.5-2.0: {effective_speed}"}
+        return {
+            "error": f"speed out of range 0.5-2.0: {effective_speed}",
+            "code": "speed_out_of_range",
+        }
     output_dir = defaults.get("output_dir", "~/tts-output/spanish")
 
     # MCP-1 path-traversal hardening. If the caller supplied `output`,
@@ -83,7 +101,10 @@ def say(
         # empty string, NUL byte (pathlib would raise mid-resolve with
         # a ValueError that escapes our error-dict contract).
         if output == "" or "\x00" in output:
-            return {"error": f"output path {output!r} is not a valid filename"}
+            return {
+                "error": f"output path {output!r} is not a valid filename",
+                "code": "path_invalid",
+            }
 
         safe_root = Path(output_dir).expanduser().resolve()
         # Join then resolve so both relative and absolute `output`
@@ -97,7 +118,10 @@ def say(
                 else Path(output).resolve()
             )
         except (OSError, ValueError) as e:
-            return {"error": f"output path {output!r} cannot be resolved: {e}"}
+            return {
+                "error": f"output path {output!r} cannot be resolved: {e}",
+                "code": "path_invalid",
+            }
 
         # Reject writing to safe_root itself — it is a directory and
         # engine.generate would fail downstream with a less clear error.
@@ -106,7 +130,8 @@ def say(
                 "error": (
                     f"output path {output!r} resolves to output_dir "
                     "itself; supply a filename under it or omit `output`."
-                )
+                ),
+                "code": "path_is_dir",
             }
 
         try:
@@ -117,7 +142,8 @@ def say(
                     f"output path {output!r} escapes output_dir "
                     f"{str(safe_root)!r}. MCP refuses path traversal; "
                     "use a path relative to output_dir or omit `output`."
-                )
+                ),
+                "code": "path_escape",
             }
         output = str(candidate)
 
@@ -136,7 +162,7 @@ def say(
         )
     except Exception as e:
         logger.error("generate() failed: %s", e, exc_info=True)
-        return {"error": f"Generation failed: {e}"}
+        return {"error": f"Generation failed: {e}", "code": "generation_failed"}
 
     return {"path": result.path, "duration_seconds": round(result.duration_seconds, 2)}
 
@@ -170,7 +196,7 @@ def list_all_voices() -> dict:
         return {"voices": summary}
     except Exception as e:
         logger.error("list_voices() failed: %s", e, exc_info=True)
-        return {"error": f"Failed to list voices: {e}"}
+        return {"error": f"Failed to list voices: {e}", "code": "generation_failed"}
 
 
 @mcp.tool()
@@ -183,18 +209,20 @@ def demo(text: str, output_dir: str = "/tmp/spanish-tts-demo", speed: float = 1.
         speed: Speed factor 0.5-2.0 (default: 1.0).
 
     Returns:
-        Dict with 'results' list of per-voice outcomes.
+        Dict with 'results' list of per-voice outcomes, or {'error': ..., 'code': ...}.
     """
     if not text or not text.strip():
-        return {"error": "text is empty"}
+        return {"error": "text is empty", "code": "text_empty"}
+    if not math.isfinite(speed):
+        return {"error": f"speed must be a finite number, got {speed}", "code": "speed_not_finite"}
     if not (0.5 <= speed <= 2.0):
-        return {"error": f"speed out of range 0.5-2.0: {speed}"}
+        return {"error": f"speed out of range 0.5-2.0: {speed}", "code": "speed_out_of_range"}
 
     from pathlib import Path
 
     voices = list_voices()
     if not voices:
-        return {"error": "No voices registered"}
+        return {"error": "No voices registered", "code": "voices_empty"}
 
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)

--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -196,7 +196,7 @@ def list_all_voices() -> dict:
         return {"voices": summary}
     except Exception as e:
         logger.error("list_voices() failed: %s", e, exc_info=True)
-        return {"error": f"Failed to list voices: {e}", "code": "generation_failed"}
+        return {"error": f"Failed to list voices: {e}", "code": "internal_error"}
 
 
 @mcp.tool()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,6 +13,7 @@ from spanish_tts.engine import (
     _clear_cache,
     _generate_lock,
     _resolve_output,
+    _validate_text,
     generate,
     generate_clone,
     generate_design,
@@ -52,6 +53,58 @@ class TestTtsResult:
         r = TtsResult(path="/tmp/foo.wav", duration_seconds=1.0)
         with pytest.raises(AttributeError):  # frozen dataclass raises FrozenInstanceError
             r.path = "/other"  # type: ignore[misc]
+
+
+class TestValidateText:
+    """Unit tests for _validate_text helper (U3-17)."""
+
+    def test_valid_ascii(self):
+        assert _validate_text("hello world") == "hello world"
+
+    def test_valid_spanish_unicode(self):
+        assert _validate_text("¡Hola, cómo estás!") == "¡Hola, cómo estás!"
+
+    def test_valid_nfc_accent(self):
+        # NFC: é (U+00E9)
+        assert _validate_text("caf\u00e9") == "caf\u00e9"
+
+    def test_valid_nfd_accent(self):
+        # NFD: e + combining accent (U+0301)
+        assert _validate_text("cafe\u0301") == "cafe\u0301"
+
+    def test_valid_mixed_scripts(self):
+        assert _validate_text("Spanish: ñ, Arabic: نعم, CJK: 你好") is not None
+
+    def test_valid_long_accent(self):
+        long_text = "a" * 9999 + "ñ"
+        assert _validate_text(long_text) == long_text
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="text is empty"):
+            _validate_text("")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match="text is empty"):
+            _validate_text("   \t\n")
+
+    def test_none_raises(self):
+        with pytest.raises((ValueError, AttributeError)):
+            _validate_text(None)  # type: ignore[arg-type]
+
+    def test_nul_byte_raises(self):
+        with pytest.raises(ValueError, match="NUL"):
+            _validate_text("hola\x00mundo")
+
+    def test_too_long_raises(self):
+        with pytest.raises(ValueError, match="too long"):
+            _validate_text("a" * 10001)
+
+    def test_exactly_max_len_accepted(self):
+        assert len(_validate_text("a" * 10000)) == 10000
+
+    def test_no_max_len(self):
+        very_long = "a" * 50000
+        assert _validate_text(very_long, max_len=None) == very_long
 
 
 class TestGenerateCloneSignature:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -73,7 +73,8 @@ class TestValidateText:
         assert _validate_text("cafe\u0301") == "cafe\u0301"
 
     def test_valid_mixed_scripts(self):
-        assert _validate_text("Spanish: ñ, Arabic: نعم, CJK: 你好") is not None
+        text = "Spanish: ñ, Arabic: نعم, CJK: 你好"
+        assert _validate_text(text) == text
 
     def test_valid_long_accent(self):
         long_text = "a" * 9999 + "ñ"
@@ -88,7 +89,7 @@ class TestValidateText:
             _validate_text("   \t\n")
 
     def test_none_raises(self):
-        with pytest.raises((ValueError, AttributeError)):
+        with pytest.raises(ValueError, match="text is empty"):
             _validate_text(None)  # type: ignore[arg-type]
 
     def test_nul_byte_raises(self):

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -269,6 +269,7 @@ class TestListAllVoicesErrorBranches:
             result = mcp.list_all_voices()
         assert "error" in result
         assert "Failed to list voices" in result["error"]
+        assert result["code"] == "internal_error"
         assert any("list_voices() failed" in r.message for r in caplog.records)
 
 
@@ -405,6 +406,7 @@ class TestErrorCodeField:
         [
             (float("nan"), "speed_not_finite"),
             (float("inf"), "speed_not_finite"),
+            (float("-inf"), "speed_not_finite"),
             (0.4999, "speed_out_of_range"),
         ],
     )
@@ -412,3 +414,11 @@ class TestErrorCodeField:
         result = bundled_presets.demo(text="hola", speed=speed)
         assert "error" in result
         assert result["code"] == expected_code
+
+    def test_demo_voices_empty_code(self, bundled_presets, monkeypatch):
+        """demo() with no registered voices returns voices_empty code."""
+        mcp = bundled_presets
+        monkeypatch.setattr(mcp, "list_voices", lambda: {})
+        result = mcp.demo(text="hola")
+        assert "error" in result
+        assert result["code"] == "voices_empty"

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -50,17 +50,22 @@ def _make_tts_result(path: str, duration: float = 1.23) -> TtsResult:
 class TestSayTextValidation:
     def test_empty_string_rejected(self, bundled_presets):
         result = bundled_presets.say(text="")
-        assert result == {"error": "text is empty"}
+        assert result == {"error": "text is empty", "code": "text_empty"}
 
     def test_whitespace_only_rejected(self, bundled_presets):
         result = bundled_presets.say(text="   \t\n")
-        assert result == {"error": "text is empty"}
+        assert result == {"error": "text is empty", "code": "text_empty"}
+
+    def test_nul_byte_rejected(self, bundled_presets):
+        result = bundled_presets.say(text="hola\x00mundo")
+        assert result == {"error": "text contains NUL byte", "code": "text_nul"}
 
     def test_text_too_long_rejected(self, bundled_presets):
         result = bundled_presets.say(text="a" * 10001)
         assert "error" in result
         assert "too long" in result["error"]
         assert "10001" in result["error"]
+        assert result["code"] == "text_too_long"
 
     def test_text_exactly_10000_accepted(self, bundled_presets, monkeypatch, tmp_path):
         mcp = bundled_presets
@@ -84,6 +89,7 @@ class TestSayVoiceNotFound:
         result = bundled_presets.say(text="hola", voice="__no_such_voice__")
         assert "error" in result
         assert "__no_such_voice__" in result["error"]
+        assert result["code"] == "voice_not_found"
 
     def test_error_lists_available_voices(self, bundled_presets):
         result = bundled_presets.say(text="hola", voice="__no_such_voice__")
@@ -140,6 +146,7 @@ class TestSayGenerateException:
         assert "error" in result
         assert "Generation failed" in result["error"]
         assert "boom" in result["error"]
+        assert result["code"] == "generation_failed"
 
     def test_generate_exception_is_logged(self, bundled_presets, tmp_path, monkeypatch, caplog):
         mcp = bundled_presets
@@ -273,11 +280,11 @@ class TestListAllVoicesErrorBranches:
 class TestDemoErrorBranches:
     def test_empty_text_returns_error(self, bundled_presets):
         result = bundled_presets.demo(text="")
-        assert result == {"error": "text is empty"}
+        assert result == {"error": "text is empty", "code": "text_empty"}
 
     def test_whitespace_text_returns_error(self, bundled_presets):
         result = bundled_presets.demo(text="  ")
-        assert result == {"error": "text is empty"}
+        assert result == {"error": "text is empty", "code": "text_empty"}
 
     def test_generates_result_per_voice(self, bundled_presets, tmp_path, monkeypatch):
         mcp = bundled_presets
@@ -344,3 +351,64 @@ class TestDemoErrorBranches:
         with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):
             mcp.demo(text="hola", output_dir=str(tmp_path / "log_demo"))
         assert any("demo generate for" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# ECO-016: stable 'code' field on all error-return branches (U3-17)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCodeField:
+    """Every MCP error return must include a stable 'code' enum value."""
+
+    @pytest.mark.parametrize(
+        "speed,expected_code",
+        [
+            (float("nan"), "speed_not_finite"),
+            (float("inf"), "speed_not_finite"),
+            (float("-inf"), "speed_not_finite"),
+            (0.4999, "speed_out_of_range"),
+            (2.0001, "speed_out_of_range"),
+        ],
+    )
+    def test_say_speed_codes(self, bundled_presets, speed, expected_code):
+        result = bundled_presets.say(text="hola", voice="neutral_male", speed=speed)
+        assert "error" in result
+        assert result["code"] == expected_code
+
+    def test_say_path_escape_has_code(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
+        result = mcp.say(text="hola", voice="neutral_male", output="../escape.wav")
+        assert result["code"] == "path_escape"
+
+    def test_say_path_is_dir_has_code(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
+        result = mcp.say(text="hola", voice="neutral_male", output=".")
+        assert result["code"] == "path_is_dir"
+
+    def test_say_path_invalid_has_code(self, bundled_presets, tmp_path, monkeypatch):
+        mcp = bundled_presets
+        monkeypatch.setattr(
+            mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
+        )
+        result = mcp.say(text="hola", voice="neutral_male", output="foo\x00.wav")
+        assert result["code"] == "path_invalid"
+
+    @pytest.mark.parametrize(
+        "speed,expected_code",
+        [
+            (float("nan"), "speed_not_finite"),
+            (float("inf"), "speed_not_finite"),
+            (0.4999, "speed_out_of_range"),
+        ],
+    )
+    def test_demo_speed_codes(self, bundled_presets, speed, expected_code):
+        result = bundled_presets.demo(text="hola", speed=speed)
+        assert "error" in result
+        assert result["code"] == expected_code


### PR DESCRIPTION
## WHY

MCP AND CLI HAD DIFFERENT TEXT VALIDATION PATHS: MCP CHECKED EMPTY/LENGTH ONLY (MISSING NUL), CLI HAD NO TEXT VALIDATION AT ALL. SPEED FALLBACK WAS FRAGILE (speed OR ...) — SPEED=0.0 FALLS THROUGH. MCP ERRORS HAD NO STABLE CODE FIELD FOR PROGRAMMATIC BRANCHING (ECO-016).

## WHAT

### Commit 1: implementation
- ADD _validate_text(text, max_len=10000) TO engine.py: REJECTS EMPTY, NUL, OVER-LENGTH. CALL FROM generate_clone + generate_design.
- CLI COVERAGE TRANSITIVE — CLI say() CALLS generate() WHICH CALLS generate_clone/generate_design. NO DUPLICATE.
- MCP say(): ADD text_nul CHECK, ADD math.isfinite GUARD ON SPEED BEFORE RANGE CHECK (speed_not_finite CODE).
- MCP demo(): ADD math.isfinite GUARD ON SPEED, ADD voices_empty CODE.
- CLI say: speed OR defaults -> speed IF speed IS NOT NONE ELSE defaults.
- ECO-016: ADD 'code' KEY TO ALL MCP ERROR RETURNS. ENUM IN CONTRACT.md.

### Commit 2: tests
- test_engine.py: TestValidateText (13 tests, Spanish Unicode: ñ, ¿, NFC/NFD, mixed scripts, max_len edge cases).
- test_mcp_errors.py: UPDATE existing exact-match assertions to include code field. ADD TestErrorCodeField (parametrized NaN/inf/speed bounds, path_escape, path_is_dir, path_invalid, demo speed codes). ADD test_nul_byte_rejected.

## TEST

- 223 PASSED (WAS 198, +25 NEW TESTS).
- pre-commit CLEAN.

## RISK / ROLLBACK

- BEHAVIOR CHANGE: MCP say() NOW REJECTS TEXT WITH NUL BYTES (CODE: text_nul). PREVIOUSLY PASSED THROUGH TO ENGINE.
- BEHAVIOR CHANGE: MCP say()/demo() SPEED NaN/INF NOW RETURNS speed_not_finite BEFORE RANGE CHECK. PREVIOUSLY: NaN MIGHT HAVE PASSED the (0.5 <= x <= 2.0) CHECK (NaN COMPARISONS RETURN FALSE).
- BEHAVIOR CHANGE: generate_clone/generate_design NOW RAISE ValueError ON EMPTY/NUL/LONG TEXT INSTEAD OF PASSING TO MODEL.
- ROLLBACK: git revert BOTH COMMITS.

CLOSES CHECKBOX U3-17 IN #15.