### PR TITLE
feat(engine): U3-9 HF MODEL REVISION PINNING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Logger hygiene: `generate_design` logs instruct body at `DEBUG` (not `INFO`) to avoid voice-persona PII in production logs (U3-18).
 - `_sandbox_path` helper in `mcp_server.py` — factors out MCP-1 path-traversal logic. Applied to `say(output=...)` and `demo(output_dir=...)` (U3-7).
 - `demo` now rejects text > 10 000 chars (`text_too_long` code) and sandboxes `output_dir` to `$HOME` or the system temp directory (U3-7).
+- `MODEL_REVISIONS` dict in `engine.py` with pinned HF commit SHAs for both models. `_get_model` passes `revision=` to `mlx_audio.tts.load` (U3-9).
+- `CONTRIBUTING.md` documents the model-revision bump process (U3-9).
 - `TtsResult` exported from `spanish_tts.__init__` (U3-19).
 - `CONTRACT.md` — stable JSON shapes + backward-compat policy for the MCP server (U3-5 part 1).
 - `LICENSE` file with full MIT text; PEP 639 migration in `pyproject.toml` (U3-1).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,10 +59,27 @@ docs(license): U3-1 ADD LICENSE FILE + PEP 639 MIGRATION
 
 ## Bumping HF model revisions (U3-9)
 
-1. Find known-good commit SHA on HF for the target model.
-2. Update the `MODELS` dict in `src/spanish_tts/engine.py`.
-3. Add a `CHANGELOG.md [Unreleased]` entry.
-4. Open a PR; CI validates the new revision on Ubuntu (mocked) and macOS (real).
+`engine.py` pins both models to specific commit SHAs in `MODEL_REVISIONS`.
+This prevents silent breakage when the upstream HF repo is updated.
+
+### Bump process
+
+1. **Find the new SHA** on the model's HF page → *Files and versions* → *Commits*
+   (or use the HF API: `python -c "from huggingface_hub import model_info; print(model_info('mlx-community/<id>').sha)"`).
+2. **Verify the commit** on the HF model card: check README diff, config.json,
+   and tokenizer for unexpected changes.
+3. **Update** `MODEL_REVISIONS` in `src/spanish_tts/engine.py`.
+4. **Test locally** on Apple Silicon:
+   ```bash
+   conda run -n qwen3-tts pytest -m "requires_mlx" -q
+   ```
+5. **Open a PR** with a `CHANGELOG.md [Unreleased]` entry:
+   ```
+   ### Changed
+   - Bump clone/design model revision to <new-sha> (tested on <date>).
+   ```
+6. CI validates the new revision on Ubuntu (mocked) and macOS (real, if CI macOS
+   job is enabled after U3-13).
 
 ## Voice schema
 

--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -74,6 +74,22 @@ MODELS = {
     "design": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit",
 }
 
+# Known-good Hugging Face commit SHAs for each model.
+#
+# These are verified-good revision hashes. Passing revision= to
+# mlx_audio.tts.load() pins the download to this exact commit and
+# prevents silent breakage when the repo is updated.
+#
+# Bump process (see CONTRIBUTING.md § "Updating model revisions"):
+#   1. Verify the new commit on the HF model card (check README, config).
+#   2. Update the SHA below.
+#   3. Test locally: `conda run -n qwen3-tts pytest -m requires_mlx -q`.
+#   4. Add a CHANGELOG entry under [Unreleased] → ### Changed.
+MODEL_REVISIONS: dict[str, str] = {
+    "clone": "e7dd0585652209fa0d7783659aad4e8a324de11c",
+    "design": "f90d617701d9f7f4ca499291e0b57f2b3c2fd2ee",
+}
+
 # Thread-safety: _model_cache is shared across threads.
 # _cache_lock guards the cache dict — prevents duplicate loads when two threads
 # call _get_model simultaneously for the same model_id.
@@ -166,14 +182,34 @@ def _get_model(model_id: str):
     Uses a module-level lock to ensure at most one thread loads a given
     model_id; subsequent callers receive the cached instance immediately
     without touching the MLX runtime.
+
+    The model is loaded at the pinned revision in :data:`MODEL_REVISIONS`
+    (if a matching entry exists), otherwise at the repo's default branch.
     """
     with _cache_lock:
         if model_id not in _model_cache:
-            from mlx_audio.tts import load_model
+            from mlx_audio.tts import load
 
-            logger.info("Loading model: %s", model_id)
-            _model_cache[model_id] = load_model(model_id)
+            revision = _revision_for(model_id)
+            logger.info("Loading model: %s (revision=%s)", model_id, revision or "default")
+            _model_cache[model_id] = load(model_id, revision=revision)
         return _model_cache[model_id]
+
+
+def _revision_for(model_id: str) -> str | None:
+    """Return the pinned revision SHA for *model_id*, or None.
+
+    Looks up ``model_id`` in :data:`MODEL_REVISIONS` by both the full ID
+    and by the short key (``"clone"``/``"design"``).
+    """
+    # Direct match first (future custom model IDs).
+    if model_id in MODEL_REVISIONS:
+        return MODEL_REVISIONS[model_id]
+    # Fall back to short-key lookup via MODELS inverse.
+    for key, mid in MODELS.items():
+        if mid == model_id:
+            return MODEL_REVISIONS.get(key)
+    return None
 
 
 def _resolve_output(output: str | None, prefix: str, output_dir: str | None = None) -> str:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -57,6 +57,7 @@ class TestLoggerHygiene:
         fake_mlx = types.ModuleType("mlx_audio")
         fake_tts = types.ModuleType("mlx_audio.tts")
         fake_tts.load_model = lambda model_id: FakeModel()
+        fake_tts.load = lambda model_id, **kw: FakeModel()
         fake_mlx.tts = fake_tts
         monkeypatch.setitem(__import__("sys").modules, "mlx_audio", fake_mlx)
         monkeypatch.setitem(__import__("sys").modules, "mlx_audio.tts", fake_tts)
@@ -255,7 +256,7 @@ class TestGenerateValidation:
 
 
 def _install_fake_load_model(monkeypatch, fake_load_model):
-    """Patch mlx_audio.tts.load_model with *fake_load_model* in sys.modules.
+    """Patch mlx_audio.tts.load and load_model with *fake_load_model* in sys.modules.
 
     Works whether mlx_audio is installed (Apple Silicon) or absent (CI).
     Returns the patched eng module for convenience.
@@ -267,10 +268,16 @@ def _install_fake_load_model(monkeypatch, fake_load_model):
 
     if "mlx_audio.tts" in sys.modules:
         monkeypatch.setattr(sys.modules["mlx_audio.tts"], "load_model", fake_load_model)
+        monkeypatch.setattr(
+            sys.modules["mlx_audio.tts"],
+            "load",
+            lambda model_id, **kw: fake_load_model(model_id),
+        )
     else:
         fake_mlx = types.ModuleType("mlx_audio")
         fake_tts = types.ModuleType("mlx_audio.tts")
         fake_tts.load_model = fake_load_model
+        fake_tts.load = lambda model_id, **kw: fake_load_model(model_id)
         fake_mlx.tts = fake_tts
         monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx)
         monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)


### PR DESCRIPTION
## WHY

_get_model LOADED MODELS AT DEFAULT BRANCH HEAD — ANY REPO UPDATE COULD SILENTLY CHANGE BEHAVIOR. SUPPLY-CHAIN RISK: A COMPROMISED OR ACCIDENTALLY-UPDATED MODEL WOULD BE PULLED AUTOMATICALLY.

## WHAT

- ADD MODEL_REVISIONS DICT WITH PINNED COMMIT SHAs (VERIFIED 2026-04-27 VIA huggingface_hub.model_info).
- ADD _revision_for(model_id) HELPER — LOOKS UP SHA BY FULL MODEL ID OR SHORT KEY.
- SWITCH _get_model FROM load_model(model_id) TO mlx_audio.tts.load(model_id, revision=...) — load() ACCEPTS revision= KWARG (load_model DOES NOT).
- FIX TestCacheLock + TestLoggerHygiene FIXTURES: PATCH load ALONGSIDE load_model. WRAP load IN LAMBDA TO DROP revision= KWARG FROM FAKES.
- ADD BUMP PROCESS DOCS IN CONTRIBUTING.md.

## TEST

- 233 PASSED (NO NEW TESTS — EXISTING CACHE LOCK TESTS COVER _get_model).
- pre-commit CLEAN.

## RISK / ROLLBACK

- BEHAVIOR CHANGE: MODEL LOADS NOW PINNED TO SPECIFIC SHA. IF SHA IS NO LONGER AVAILABLE ON HF (UNLIKELY), LOAD FAILS. BUMP PROCESS DOCUMENTED.
- ROLLBACK: git revert THIS COMMIT (REVERTS TO UNPINNED LOADS).

CLOSES CHECKBOX U3-9 IN #15.