### PR TITLE
feat(init): U3-8 __version__ FROM importlib.metadata + get_version MCP TOOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `demo` now rejects text > 10 000 chars (`text_too_long` code) and sandboxes `output_dir` to `$HOME` or the system temp directory (U3-7).
 - `MODEL_REVISIONS` dict in `engine.py` with pinned HF commit SHAs for both models. `_get_model` passes `revision=` to `mlx_audio.tts.load` (U3-9).
 - `CONTRIBUTING.md` documents the model-revision bump process (U3-9).
+- `__version__` in `__init__.py` now read from `importlib.metadata` — single source of truth from `pyproject.toml` (U3-8).
+- `get_version()` MCP tool returns `{"version": ..., "package": ...}` for skill compatibility probing (U3-8).
 - `TtsResult` exported from `spanish_tts.__init__` (U3-19).
 - `CONTRACT.md` — stable JSON shapes + backward-compat policy for the MCP server (U3-5 part 1).
 - `LICENSE` file with full MIT text; PEP 639 migration in `pyproject.toml` (U3-1).

--- a/src/spanish_tts/__init__.py
+++ b/src/spanish_tts/__init__.py
@@ -1,7 +1,12 @@
 """spanish-tts: Curated Spanish TTS voices using Qwen3-TTS."""
 
-__version__ = "0.3.0"
+try:
+    from importlib.metadata import PackageNotFoundError, version
+
+    __version__: str = version("qwen3-tts-spanish-voices")
+except PackageNotFoundError:  # editable install not yet built
+    __version__ = "0.0.0+dev"
 
 from spanish_tts.engine import TtsResult
 
-__all__ = ["TtsResult"]
+__all__ = ["TtsResult", "__version__"]

--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
+from spanish_tts import __version__
 from spanish_tts.config import get_defaults, get_voice, list_voices
 from spanish_tts.engine import generate
 
@@ -200,6 +201,19 @@ def list_all_voices() -> dict:
     except Exception as e:
         logger.error("list_voices() failed: %s", e, exc_info=True)
         return {"error": f"Failed to list voices: {e}", "code": "internal_error"}
+
+
+@mcp.tool()
+def get_version() -> dict:
+    """Return the installed package version.
+
+    Callers can use this to verify skill/server compatibility before invoking
+    other tools.  The ``version`` field follows Semantic Versioning.
+
+    Returns:
+        Dict with ``version`` (str) and ``package`` (str).
+    """
+    return {"version": __version__, "package": "qwen3-tts-spanish-voices"}
 
 
 @mcp.tool()

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -57,11 +57,13 @@ def _list_tools(mcp_obj):
 
 
 class TestToolInventory:
-    def test_exactly_three_tools(self, mcp_module):
-        """CONTRACT: exactly 3 tools — say, list_all_voices, demo."""
+    def test_exactly_four_tools(self, mcp_module):
+        """CONTRACT: exactly 4 tools — say, list_all_voices, demo, get_version."""
         tools = _list_tools(mcp_module)
         names = {t.name for t in tools}
-        assert names == {"say", "list_all_voices", "demo"}, f"Unexpected tools: {names}"
+        assert names == {"say", "list_all_voices", "demo", "get_version"}, (
+            f"Unexpected tools: {names}"
+        )
 
     def test_say_tool_description_present(self, mcp_module):
         tools = {t.name: t for t in _list_tools(mcp_module)}
@@ -78,6 +80,26 @@ class TestToolInventory:
     def test_demo_description_present(self, mcp_module):
         tools = {t.name: t for t in _list_tools(mcp_module)}
         assert tools["demo"].description
+
+    def test_get_version_description_present(self, mcp_module):
+        tools = {t.name: t for t in _list_tools(mcp_module)}
+        assert tools["get_version"].description
+
+
+class TestGetVersionShape:
+    def test_get_version_returns_version_and_package(self, mcp_module):
+        """CONTRACT: get_version returns version (str) and package (str)."""
+        result = _call(mcp_module, "get_version", {})
+        assert "version" in result, result
+        assert "package" in result, result
+        assert isinstance(result["version"], str)
+        assert result["package"] == "qwen3-tts-spanish-voices"
+
+    def test_get_version_no_required_params(self, mcp_module):
+        """CONTRACT: get_version takes no required parameters."""
+        tools = {t.name: t for t in _list_tools(mcp_module)}
+        schema = tools["get_version"].inputSchema
+        assert schema.get("required", []) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## WHY

__init__.py HAD A HARDCODED __version__ STRING (0.1.0 THEN BUMPED TO 0.3.0 MANUALLY) — DRIFTS OUT OF SYNC WITH pyproject.toml BETWEEN BUMPS. get_version() MCP TOOL ENABLES HERMES SKILL TO PROBE COMPATIBILITY WITHOUT PARSING ERROR MESSAGES.

## WHAT

- __init__.py: __version__ = importlib.metadata.version('qwen3-tts-spanish-voices'). FALLBACK '0.0.0+dev' FOR EDITABLE INSTALLS NOT YET REBUILT.
- mcp_server.py: ADD get_version() TOOL → {'version': str, 'package': str}. NO REQUIRED PARAMS.
- test_mcp_protocol.py: UPDATE TestToolInventory TO EXPECT 4 TOOLS. ADD TestGetVersionShape.

## TEST

- 236 PASSED (WAS 233, +3). pre-commit CLEAN.

CLOSES CHECKBOX U3-8 IN #15.