### PR TITLE
feat(mcp): U3-14 console script + background preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CONTRIBUTING.md` documents the model-revision bump process (U3-9).
 - `__version__` in `__init__.py` now read from `importlib.metadata` — single source of truth from `pyproject.toml` (U3-8).
 - `get_version()` MCP tool returns `{"version": ..., "package": ...}` for skill compatibility probing (U3-8).
+- `spanish-tts-mcp` console script added to `pyproject.toml` `[project.scripts]` (U3-14).
+- `_preload_models` moved to background daemon thread so MCP stdio handshake (`list_tools`, `initialize`) responds immediately without blocking on model downloads (U3-14).
 - `TtsResult` exported from `spanish_tts.__init__` (U3-19).
 - `CONTRACT.md` — stable JSON shapes + backward-compat policy for the MCP server (U3-5 part 1).
 - `LICENSE` file with full MIT text; PEP 639 migration in `pyproject.toml` (U3-1).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ Changelog = "https://github.com/alblez/qwen3-tts-spanish-voices/blob/main/CHANGE
 
 [project.scripts]
 spanish-tts = "spanish_tts.cli:cli"
+spanish-tts-mcp = "spanish_tts.mcp_server:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -5,18 +5,20 @@ can call them without subprocess overhead. The MLX model stays loaded
 across calls via engine._model_cache.
 
 Usage:
-    python -m spanish_tts.mcp_server
+    python -m spanish_tts.mcp_server          # or:
+    spanish-tts-mcp                            # console script
 
 Hermes config.yaml:
     mcp_servers:
       spanish-tts:
-        command: ["conda", "run", "-n", "qwen3-tts", "python", "-m", "spanish_tts.mcp_server"]
+        command: ["conda", "run", "-n", "qwen3-tts", "spanish-tts-mcp"]
 """
 
 import logging
 import math
 import sys
 import tempfile
+import threading
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -320,14 +322,18 @@ def _preload_models():
 
 
 def main():
-    """Entry point for python -m spanish_tts.mcp_server."""
+    """Entry point for python -m spanish_tts.mcp_server or the spanish-tts-mcp script."""
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
         stream=sys.stderr,
     )
-    logger.info("Starting spanish-tts MCP server")
-    _preload_models()
+    logger.info("Starting spanish-tts MCP server v%s", __version__)
+    # Start preload in a background daemon thread so the stdio MCP handshake
+    # (list_tools, initialize) responds immediately without waiting for model
+    # downloads.  mcp.run() is a blocking call — preload must not block it.
+    t = threading.Thread(target=_preload_models, daemon=True, name="preload-models")
+    t.start()
     mcp.run()
 
 


### PR DESCRIPTION
## WHY

MCP SERVER HAD NO INSTALLED CONSOLE SCRIPT — HERMES SKILL NEEDED FULL 'python -m' INVOCATION. _preload_models BLOCKED mcp.run() — list_tools COULD NOT RESPOND DURING MODEL DOWNLOAD (~20s ON FIRST RUN).

## WHAT

- pyproject.toml: ADD spanish-tts-mcp = 'spanish_tts.mcp_server:main'.
- mcp_server.py: START _preload_models IN threading.Thread(daemon=True) BEFORE mcp.run(). SERVER RESPONDS IMMEDIATELY; WARMUP RUNS CONCURRENTLY.
- try/except PRESERVED AROUND warmup — FAILURE IS NON-FATAL PER GOTCHA #13.

## TEST

- 236 PASSED (NO CHANGE — PRELOAD THREAD IS DAEMON). pre-commit CLEAN.

CLOSES CHECKBOX U3-14 IN #15.