### PR TITLE
feat(schema): U3-15 VOICE source_license + source_url FIELDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `get_version()` MCP tool returns `{"version": ..., "package": ...}` for skill compatibility probing (U3-8).
 - `spanish-tts-mcp` console script added to `pyproject.toml` `[project.scripts]` (U3-14).
 - `_preload_models` moved to background daemon thread so MCP stdio handshake (`list_tools`, `initialize`) responds immediately without blocking on model downloads (U3-14).
+- `source_license` and `source_url` optional keys added to voice schema (U3-15). `curate.py export` writes `GPL-3.0` + HF dataset card URL. CLI `add-ref --license` flag defaults to `user-supplied-unspecified`.
 - `TtsResult` exported from `spanish_tts.__init__` (U3-19).
 - `CONTRACT.md` — stable JSON shapes + backward-compat policy for the MCP server (U3-5 part 1).
 - `LICENSE` file with full MIT text; PEP 639 migration in `pyproject.toml` (U3-1).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,15 @@ voices:
     description: <string>          # optional
     ref_audio: <path>              # required for clone voices
     instruct: <string>             # required for design voices
-    source_license: <SPDX string>  # optional (e.g. GPL-3.0)
-    source_url: <url>              # optional
+    source_license: <SPDX string>  # optional (e.g. "GPL-3.0", "CC-BY-4.0")
+    source_url: <url>              # optional (HF dataset card or original source)
 ```
+
+`source_license` and `source_url` are optional but **strongly recommended**
+for any voice built from third-party audio.  `curate.py export` automatically
+sets `source_license: "GPL-3.0"` and `source_url` to the VoxForge HF card.
+The CLI `add-ref --license <SPDX>` flag writes `source_license`; omitting it
+writes `"user-supplied-unspecified"` as a placeholder.
 
 Clone voices built from VoxForge-derived audio must set
 `source_license: GPL-3.0` and `source_url` pointing to the HF dataset card.

--- a/scripts/curate.py
+++ b/scripts/curate.py
@@ -237,6 +237,7 @@ def export(speaker_id, name, clip_index, min_duration, max_duration):
     sf.write(str(ref_path), audio_array, sr)
 
     # Register voice
+    _HF_DATASET_CARD = f"https://huggingface.co/datasets/{DATASET_ID}"
     voice_data = {
         "type": "clone",
         "ref_audio": str(ref_path),
@@ -246,6 +247,8 @@ def export(speaker_id, name, clip_index, min_duration, max_duration):
         "language": "Spanish",
         "source_speaker": speaker_id,
         "source_audio_id": meta["audio_id"],
+        "source_license": "GPL-3.0",
+        "source_url": _HF_DATASET_CARD,
     }
     add_voice(name, voice_data)
 

--- a/src/spanish_tts/cli.py
+++ b/src/spanish_tts/cli.py
@@ -88,7 +88,14 @@ def list_cmd():
 @click.argument("transcript")
 @click.option("--accent", default="neutral", help="Accent label (e.g. mexico, spain, argentina).")
 @click.option("--gender", type=click.Choice(["male", "female"]), required=True)
-def add_ref(name, audio_path, transcript, accent, gender):
+@click.option(
+    "--license",
+    "source_license",
+    default="user-supplied-unspecified",
+    help="SPDX license of the reference audio (e.g. 'GPL-3.0', 'CC-BY-4.0').",
+)
+@click.option("--source-url", default=None, help="URL to the original audio source.")
+def add_ref(name, audio_path, transcript, accent, gender, source_license, source_url):
     """Register a clone voice from a reference audio file."""
     import shutil
     from pathlib import Path
@@ -99,14 +106,17 @@ def add_ref(name, audio_path, transcript, accent, gender):
     dest = ref_dir / f"{name}{src.suffix}"
     shutil.copy2(src, dest)
 
-    voice_data = {
+    voice_data: dict = {
         "type": "clone",
         "ref_audio": str(dest),
         "ref_text": transcript,
         "accent": accent,
         "gender": gender,
         "language": "Spanish",
+        "source_license": source_license,
     }
+    if source_url is not None:
+        voice_data["source_url"] = source_url
     add_voice(name, voice_data)
     click.echo(f"Added clone voice '{name}' from {src.name} ({accent}, {gender})")
 

--- a/src/spanish_tts/config.py
+++ b/src/spanish_tts/config.py
@@ -74,6 +74,9 @@ def _validate_voices_schema(data: dict[str, Any], source: Path) -> None:
     - ``data["voices"]`` is a mapping.
     - Each entry has ``type`` in ``{"clone", "design"}``.
     - Clone entries have ``ref_audio`` as a non-empty string.
+
+    Optional keys ``source_license`` (SPDX string) and ``source_url`` (str)
+    are allowed but not validated beyond being strings when present.
     """
     voices = data.get("voices", {})
     if not isinstance(voices, dict):
@@ -96,6 +99,12 @@ def _validate_voices_schema(data: dict[str, Any], source: Path) -> None:
             if not isinstance(ref, str) or not ref:
                 raise ValueError(
                     f"Clone voice {name!r} must have a non-empty string 'ref_audio' in {source}"
+                )
+        for opt_key in ("source_license", "source_url"):
+            val = entry.get(opt_key)
+            if val is not None and not isinstance(val, str):
+                raise ValueError(
+                    f"Voice {name!r} key {opt_key!r} must be a string when present in {source}"
                 )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,7 @@ class TestAddRefCommand:
         assert result.exit_code == 0
         assert "--accent" in result.output
         assert "--gender" in result.output
+        assert "--license" in result.output
 
 
 class TestAddDesignCommand:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -386,3 +386,57 @@ class TestConfigDirEnvGuard:
 
         with pytest.raises(ValueError, match="HOME"):
             get_config_dir()
+
+
+class TestVoicesSchemaOptionalKeys:
+    """U3-15: source_license and source_url are optional allowed keys."""
+
+    def test_source_license_str_accepted(self):
+        data = {
+            "voices": {
+                "v1": {
+                    "type": "clone",
+                    "ref_audio": "/tmp/a.wav",
+                    "source_license": "GPL-3.0",
+                }
+            }
+        }
+        _validate_voices_schema(data, Path("test.yaml"))  # must not raise
+
+    def test_source_url_str_accepted(self):
+        data = {
+            "voices": {
+                "v1": {
+                    "type": "design",
+                    "instruct": "x",
+                    "source_url": "https://huggingface.co/datasets/ciempiess/voxforge_spanish",
+                }
+            }
+        }
+        _validate_voices_schema(data, Path("test.yaml"))  # must not raise
+
+    def test_source_license_non_string_raises(self):
+        data = {
+            "voices": {
+                "v1": {
+                    "type": "design",
+                    "instruct": "x",
+                    "source_license": 42,  # not a string
+                }
+            }
+        }
+        with pytest.raises(ValueError, match="source_license"):
+            _validate_voices_schema(data, Path("test.yaml"))
+
+    def test_source_url_none_ignored(self):
+        """source_url: null is treated as absent (None)."""
+        data = {
+            "voices": {
+                "v1": {
+                    "type": "design",
+                    "instruct": "x",
+                    "source_url": None,
+                }
+            }
+        }
+        _validate_voices_schema(data, Path("test.yaml"))  # must not raise


### PR DESCRIPTION
## WHY

VOICES BUILT FROM VoxForge GPL-3.0 AUDIO HAD NO LICENSE METADATA IN THE REGISTRY — LICENSE INFORMATION WAS ONLY IN NOTICE FILE AND COMMENTS. A USER SHARING THEIR voices.yaml HAD NO WAY TO COMMUNICATE THE UPSTREAM LICENSE.

## WHAT

- config.py _validate_voices_schema: ACCEPT source_license + source_url AS OPTIONAL STRING KEYS. RAISE ValueError IF PRESENT AS NON-STRING.
- curate.py export: WRITE source_license='GPL-3.0' + source_url=HF DATASET CARD URL.
- cli.py add-ref: ADD --license FLAG (DEFAULT 'user-supplied-unspecified'). OPTIONAL --source-url FLAG.
- CONTRIBUTING.md: SCHEMA DOCS UPDATED WITH LICENSE GUIDANCE.

## TEST

- 240 PASSED (WAS 236, +4). pre-commit CLEAN.

CLOSES CHECKBOX U3-15 IN #15.