### PR TITLE
ci: U3-13 ADD Python 3.13 + pre-commit JOB + macOS MATRIX + cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:  # allows manual trigger for macOS job
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -29,12 +34,28 @@ jobs:
       - name: ruff format --check
         run: ruff format --check .
 
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files --show-diff-on-failure
+
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -60,3 +81,38 @@ jobs:
 
       - name: Run tests (skip slow / mlx-dependent)
         run: pytest -q -m "not slow"
+
+  test-macos:
+    # macOS job: exercises slow + requires_mlx tests with real Apple Silicon.
+    # Runs on workflow_dispatch only — model downloads (~2 GB) are too costly
+    # for every push/PR. Enable on a nightly schedule once HF cache is warm.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Cache Hugging Face models
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-${{ hashFiles('src/spanish_tts/engine.py') }}
+          restore-keys: hf-models-
+
+      - name: Install package (with mlx extras for Apple Silicon)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all]"
+          pip install pytest
+
+      - name: Show versions
+        run: |
+          python --version
+          pip show qwen3-tts-spanish-voices | head -5 || true
+
+      - name: Run slow + mlx tests
+        run: pytest -q -m "slow or requires_mlx"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,10 @@
 #   pre-commit install                     # commit-stage hooks
 #   pre-commit install --hook-type pre-push # push-stage pytest smoke
 
-default_language_version:
-  python: python3.11
+# Note: default_language_version is intentionally absent so pre-commit uses
+# whatever Python is on PATH. CI uses python3.12; local devs use python3.11.
+# The pytest-fast hook uses `language: system` so it always runs in the
+# caller's active env.
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `spanish-tts-mcp` console script added to `pyproject.toml` `[project.scripts]` (U3-14).
 - `_preload_models` moved to background daemon thread so MCP stdio handshake (`list_tools`, `initialize`) responds immediately without blocking on model downloads (U3-14).
 - `source_license` and `source_url` optional keys added to voice schema (U3-15). `curate.py export` writes `GPL-3.0` + HF dataset card URL. CLI `add-ref --license` flag defaults to `user-supplied-unspecified`.
+- CI matrix extended to Python 3.13 (Ubuntu). `pre-commit` job added. `concurrency: cancel-in-progress` added. `test-macos` job added (workflow_dispatch only; caches `~/.cache/huggingface`) (U3-13).
 - `TtsResult` exported from `spanish_tts.__init__` (U3-19).
 - `CONTRACT.md` — stable JSON shapes + backward-compat policy for the MCP server (U3-5 part 1).
 - `LICENSE` file with full MIT text; PEP 639 migration in `pyproject.toml` (U3-1).


### PR DESCRIPTION
## WHY

CI ONLY TESTED 3.11/3.12. NO pre-commit CHECK IN CI. NO CONCURRENCY CANCEL. NO macOS PATH FOR MLX TESTS.

## WHAT

- Python 3.13 ADDED TO UBUNTU MATRIX (3 VERSIONS TOTAL).
- pre-commit JOB: RUNS pre-commit run --all-files --show-diff-on-failure.
- concurrency: cancel-in-progress ON ci-{ref} GROUP.
- test-macos JOB: workflow_dispatch ONLY (COST GUARD). Runs pytest -m 'slow or requires_mlx'. CACHES ~/.cache/huggingface VIA SHA-PINNED actions/cache@0057852b.
- ALL NEW ACTIONS SHA-PINNED (NO NEW FLOATING TAGS).

## RISK / ROLLBACK

- WORKFLOW-TOUCHING PR — SSH MERGE PATH USED PER §7.
- test-macos GATED ON workflow_dispatch — DOES NOT RUN ON EVERY PR. SAFE.

CLOSES CHECKBOX U3-13 IN #15.