### PR TITLE
chore: L-PACK — BATCH ONE-LINE FIXES (L-NEW-1..4, L-4/12/14, CI-009, ECO-017, LIC-006)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,9 @@ HANDOVER_PROMPT.md
 REVIEW_STATE.md
 REVIEW_v*.md
 .audit/
+
+# Coverage artefacts
 .coverage
+htmlcov/
+.mypy_cache/
+coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,3 +101,10 @@ Umbrella #2: speed correctness, CI, hardening, and developer tooling.
 ## [0.1.0]
 
 Initial release. See git history for feature set.
+
+---
+
+[Unreleased]: https://github.com/alblez/qwen3-tts-spanish-voices/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/alblez/qwen3-tts-spanish-voices/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/alblez/qwen3-tts-spanish-voices/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/alblez/qwen3-tts-spanish-voices/releases/tag/v0.1.0

--- a/scripts/curate.py
+++ b/scripts/curate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 #!/usr/bin/env python3
 """Curate Spanish voice references from VoxForge Spanish corpus.
 

--- a/src/spanish_tts/__init__.py
+++ b/src/spanish_tts/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """spanish-tts: Curated Spanish TTS voices using Qwen3-TTS."""
 
 try:

--- a/src/spanish_tts/cli.py
+++ b/src/spanish_tts/cli.py
@@ -31,7 +31,8 @@ def cli():
 )
 @click.option("--output", "-o", default=None, help="Output .wav path.")
 @click.option("--play", "-p", is_flag=True, help="Auto-play with afplay after generating.")
-def say(text, voice, speed, output, play):
+@click.option("--stream", is_flag=True, default=False, help="Use streaming decode (lower memory).")
+def say(text, voice, speed, output, play, stream):
     """Generate speech from text using a registered voice."""
     defaults = get_defaults()
     voice_config = get_voice(voice)
@@ -51,6 +52,7 @@ def say(text, voice, speed, output, play):
         speed=effective_speed,
         output=output,
         output_dir=output_dir,
+        stream=stream,
     )
     # Print path to stdout for piping
     click.echo(result)

--- a/src/spanish_tts/cli.py
+++ b/src/spanish_tts/cli.py
@@ -58,7 +58,7 @@ def say(text, voice, speed, output, play):
     if play:
         import subprocess
 
-        subprocess.run(["afplay", str(result)])
+        subprocess.run(["/usr/bin/afplay", str(result)])
 
 
 @cli.command("list")

--- a/src/spanish_tts/cli.py
+++ b/src/spanish_tts/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """CLI for spanish-tts."""
 
 import click

--- a/src/spanish_tts/config.py
+++ b/src/spanish_tts/config.py
@@ -272,6 +272,20 @@ def add_voice(
             )
 
     data["voices"][name] = voice_data
+
+    # L-12: warn if ref_audio path doesn't exist at registration time.
+    # Non-fatal — the file may be created later or the path may be relative
+    # to a different CWD.  Synthesis will raise FileNotFoundError at call time.
+    if voice_data.get("type") == "clone":
+        ref = voice_data.get("ref_audio", "")
+        if ref and not Path(ref).expanduser().is_file():
+            logger.warning(
+                "Clone voice %r: ref_audio %r does not exist yet. "
+                "Synthesis will fail until the file is present.",
+                name,
+                ref,
+            )
+
     save_voices(data, voices_file)
 
 

--- a/src/spanish_tts/config.py
+++ b/src/spanish_tts/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Configuration management for spanish-tts."""
 
 import logging
@@ -287,6 +288,7 @@ def add_voice(
             )
 
     save_voices(data, voices_file)
+    logger.info("Voice %r registered (type=%s).", name, voice_data.get("type", "unknown"))
 
 
 def list_voices(voices_file: Path | None = None) -> dict[str, dict[str, Any]]:

--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -41,6 +41,20 @@ class TtsResult:
 # Speed range constants
 SPEED_MIN, SPEED_MAX = 0.5, 2.0
 
+# Language name → Qwen3-TTS lang_code mapping (used by generate_design).
+LANG_MAP: dict[str, str] = {
+    "Spanish": "spanish",
+    "English": "english",
+    "Chinese": "chinese",
+    "French": "french",
+    "German": "german",
+    "Italian": "italian",
+    "Portuguese": "portuguese",
+    "Japanese": "japanese",
+    "Korean": "korean",
+    "Russian": "russian",
+}
+
 _MAX_TEXT_LEN = 10_000
 
 
@@ -352,19 +366,7 @@ def generate_design(
         backward-compatible callers.
     """
     _validate_text(text)
-    lang_map = {
-        "Spanish": "spanish",
-        "English": "english",
-        "Chinese": "chinese",
-        "French": "french",
-        "German": "german",
-        "Italian": "italian",
-        "Portuguese": "portuguese",
-        "Japanese": "japanese",
-        "Korean": "korean",
-        "Russian": "russian",
-    }
-    lang_code = lang_map.get(language, "spanish")
+    lang_code = LANG_MAP.get(language, "spanish")
 
     with _generate_lock:
         model = _get_model(model_id or MODELS["design"])

--- a/src/spanish_tts/engine.py
+++ b/src/spanish_tts/engine.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """TTS engine wrapping Qwen3-TTS MLX for clone and design modes."""
 
 import logging

--- a/src/spanish_tts/mcp_server.py
+++ b/src/spanish_tts/mcp_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """MCP server for spanish-tts.
 
 Exposes Qwen3-TTS Spanish voice generation as MCP tools so Hermes Agent

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,7 @@ class TestSayCommand:
         assert "--voice" in result.output
         assert "--speed" in result.output
         assert "--play" in result.output
+        assert "--stream" in result.output
 
 
 class TestAddRefCommand:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,11 +120,13 @@ class TestAddVoice:
                 {"type": "clone", "ref_audio": "/tmp/new.wav"},
                 tmp_voices_file,
             )
-        assert len(caplog.records) == 1
-        rec = caplog.records[0]
+        # At least the overwrite warning must be present. A second WARNING may
+        # appear if /tmp/new.wav doesn't exist (L-12 ref_audio check).
+        overwrite_recs = [r for r in caplog.records if "overwritten" in r.message.lower()]
+        assert len(overwrite_recs) == 1
+        rec = overwrite_recs[0]
         assert rec.levelno == logging.WARNING
         assert "test_clone" in rec.message
-        assert "overwritten" in rec.message.lower()
         assert "CHANGES" not in rec.message  # must not route through the type-change branch
         # Verify the overwrite actually persisted
         updated = get_voice("test_clone", tmp_voices_file)
@@ -138,8 +140,9 @@ class TestAddVoice:
                 {"type": "clone", "ref_audio": "/tmp/new.wav"},
                 tmp_voices_file,
             )
-        assert len(caplog.records) == 1
-        rec = caplog.records[0]
+        type_change_recs = [r for r in caplog.records if "CHANGES" in r.message]
+        assert len(type_change_recs) == 1
+        rec = type_change_recs[0]
         assert rec.levelno == logging.WARNING
         assert "test_design" in rec.message
         assert "design" in rec.message

--- a/tests/test_engine_integration.py
+++ b/tests/test_engine_integration.py
@@ -15,6 +15,7 @@ import pytest
 
 import spanish_tts.engine as eng
 from spanish_tts.engine import (
+    LANG_MAP,
     MODELS,
     _cache_lock,
     _clear_cache,
@@ -138,23 +139,10 @@ class TestGetModelCacheHit:
 # D. generate_design language mapping — all 10 lang_map entries
 # ---------------------------------------------------------------------------
 
-_LANG_MAP = {
-    "Spanish": "spanish",
-    "English": "english",
-    "Chinese": "chinese",
-    "French": "french",
-    "German": "german",
-    "Italian": "italian",
-    "Portuguese": "portuguese",
-    "Japanese": "japanese",
-    "Korean": "korean",
-    "Russian": "russian",
-}
-
 
 @pytest.mark.slow
 @pytest.mark.requires_mlx
-@pytest.mark.parametrize("language,expected_code", list(_LANG_MAP.items()))
+@pytest.mark.parametrize("language,expected_code", list(LANG_MAP.items()))
 def test_generate_design_language_mapping(monkeypatch, tmp_path, language, expected_code):
     """generate_design passes the correct lang_code to model.generate() for each language."""
     captured = {}

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -139,9 +139,11 @@ class TestSayGenerateException:
         monkeypatch.setattr(
             mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
         )
-        monkeypatch.setattr(
-            mcp, "generate", lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))
-        )
+
+        def _raise_boom(**kw):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(mcp, "generate", _raise_boom)
         result = mcp.say(text="hola", voice="neutral_male")
         assert "error" in result
         assert "Generation failed" in result["error"]
@@ -153,9 +155,11 @@ class TestSayGenerateException:
         monkeypatch.setattr(
             mcp, "get_defaults", lambda: {"speed": 1.0, "output_dir": str(tmp_path)}
         )
-        monkeypatch.setattr(
-            mcp, "generate", lambda **kw: (_ for _ in ()).throw(RuntimeError("kaboom"))
-        )
+
+        def _raise_kaboom(**kw):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(mcp, "generate", _raise_kaboom)
         with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):
             mcp.say(text="hola", voice="neutral_male")
         assert any("generate() failed" in r.message for r in caplog.records)
@@ -262,9 +266,11 @@ class TestListAllVoicesErrorBranches:
 
     def test_list_voices_exception_returns_error_dict(self, bundled_presets, monkeypatch, caplog):
         mcp = bundled_presets
-        monkeypatch.setattr(
-            mcp, "list_voices", lambda **kw: (_ for _ in ()).throw(RuntimeError("broken"))
-        )
+
+        def _raise_broken(**kw):
+            raise RuntimeError("broken")
+
+        monkeypatch.setattr(mcp, "list_voices", _raise_broken)
         with caplog.at_level(logging.ERROR, logger="spanish_tts.mcp_server"):
             result = mcp.list_all_voices()
         assert "error" in result
@@ -324,15 +330,12 @@ class TestDemoErrorBranches:
         mcp = bundled_presets
         first = list(mcp.list_voices().keys())[0]
 
-        monkeypatch.setattr(
-            mcp,
-            "generate",
-            lambda **kw: (
-                (_ for _ in ()).throw(RuntimeError("boom"))
-                if kw["output"].endswith(f"{first}.wav")
-                else _make_tts_result(kw["output"])
-            ),
-        )
+        def _partial_fail(**kw):
+            if kw["output"].endswith(f"{first}.wav"):
+                raise RuntimeError("boom")
+            return _make_tts_result(kw["output"])
+
+        monkeypatch.setattr(mcp, "generate", _partial_fail)
         result = mcp.demo(text="hola", output_dir=str(tmp_path / "err_field"))
         failed = [r for r in result["results"] if r["voice"] == first]
         assert failed

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -164,7 +164,8 @@ class TestCLISpeedValidation:
                 with patch("spanish_tts.cli.get_defaults", return_value={}):
                     result = runner.invoke(say, ["test", "--speed", "0.5"])
                     # Should not error on speed parsing
-                    assert "out of range" not in result.output.lower() or result.exit_code == 0
+                    assert "out of range" not in result.output.lower()
+                    assert result.exit_code == 0
 
     def test_cli_speed_accept_boundary_max(self):
         """CLI accepts --speed 2.0."""
@@ -179,7 +180,8 @@ class TestCLISpeedValidation:
             ):
                 with patch("spanish_tts.cli.get_defaults", return_value={}):
                     result = runner.invoke(say, ["test", "--speed", "2.0"])
-                    assert "out of range" not in result.output.lower() or result.exit_code == 0
+                    assert "out of range" not in result.output.lower()
+                    assert result.exit_code == 0
 
 
 class TestMCPSpeedValidation:


### PR DESCRIPTION
## WHY

BATCH OF LOW-SEVERITY FIXES ACCUMULATED ACROSS AUDIT AND WAVE 3-5 REVIEW. ONE ATOMIC COMMIT PER FIX.

## WHAT

| Commit | Fix |
|--------|-----|
| L-NEW-1 | Fix weak `or` assertion in CLI boundary tests (AND semantics) |
| L-NEW-2 | Export `LANG_MAP` from engine.py; use in integration test |
| L-NEW-3 | CHANGELOG Keep-a-Changelog comparison links |
| L-NEW-4 | Replace generator-throw idiom with named `raise` functions |
| L-4 | Absolute `/usr/bin/afplay` path in CLI |
| L-12 | Warn when `ref_audio` path missing at `add_voice` time |
| L-14 | Add `--stream` flag to CLI `say` command |
| CI-009 | Add `htmlcov/`, `.mypy_cache/`, `coverage.xml` to `.gitignore` |
| ECO-017 | `logger.info` on successful `add_voice` registration |
| LIC-006 | SPDX-License-Identifier: MIT header on all `src/*.py` + `scripts/curate.py` |

## TEST

- 240 PASSED (UNCHANGED). pre-commit CLEAN.

CLOSES L-PACK CHECKBOX IN #15.